### PR TITLE
Backport from master: Define variable 'sysconfdir' in 'kopano.pc'

### DIFF
--- a/common/kopano.pc.in
+++ b/common/kopano.pc.in
@@ -2,6 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
+sysconfdir=@sysconfdir@
 uscriptlibdir=@uscriptlibdir@
 uscriptconfdir=@uscriptconfdir@
 


### PR DESCRIPTION
Since `kopano.pc` uses `$sysconfdir` in `$uscriptconfdir` for nightly
builds of Kopano Core, it should be defined. Otherwise the regression
tests of pam_mapi are simply failing, given `pkg-config` returns just
a failure exit/return code.

```
$ pkg-config --exists --print-errors "kopano >= 8.0.0"
Variable 'sysconfdir' not defined in '/usr/lib64/pkgconfig/kopano.pc'
$
$ echo $?
1
$
```

```
$ rpm -qf /usr/lib64/pkgconfig/kopano.pc
kopano-devel-8.7.80.169-44.1.x86_64
$
```

```
$ grep sysconfdir /usr/lib64/pkgconfig/kopano.pc
uscriptconfdir=${sysconfdir}/kopano/userscripts
$
```