### PR TITLE
Fix regression with commit 88755037a1d  (forward_whitelist_domains_file option)

### DIFF
--- a/ECtools/rest/kopano-mfr.py
+++ b/ECtools/rest/kopano-mfr.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import glob
 import logging

--- a/RELNOTES.txt
+++ b/RELNOTES.txt
@@ -1,3 +1,20 @@
+8.6.91 (8.7 beta)
+=================
+Fixes:
+* server: fix disappearing inbox rules [KC-1359,KF-1940]
+* kopano-dbadm: new action "usmp" and "usmp-charset"
+* server: no more automatic upgrade to utf8mb4,
+  use `kopano-dbadm usmp` instead [KF-1394]
+Enhancements:
+* server: reduction of search folder overhead (have ECSearchFolders use a thread pool)
+* server: implement faster LDAP-based Global Addressbook searches [KC-1261]
+* ibrule: show contents of address lists
+Changes:
+* ol-schema-migrate: add back openldap support with -X option
+  (ol-schema-migrate was earlier updated to a new upstream version,
+  which changed attribute names to 389-ds)
+
+
 8.6.90 (8.7 beta)
 =================
 Fixes:
@@ -9,7 +26,6 @@ Enhancements:
   window, 60-second step). PNG image generation is not included (CPU intensive,
   and styling depends on user taste).
   To enable, set statsclient_interval=60 in dagent.cfg/server.cfg/spooler.cfg.
-* kopano-dbadm: new action "usmp" and "usmp-charset"
 Changes:
 * dagent/spooler: the custom plaintext protocol of StatsClient is
   replaced by a JSON variant [KC-1264]

--- a/RELNOTES.txt
+++ b/RELNOTES.txt
@@ -86,6 +86,8 @@ Fixes:
 * libserver: restore a missing KCERR_NOT_FOUND return code in getStore
 Enhancements:
 * dbadm: new action "usmp-shrink-columns"
+* dagent: add directive to read whitelist domains and body from file
+  [KC-1278, KC-1279]
 Packaging:
 * Support for gsoap 2.8.73
 

--- a/common/ECThreadPool.cpp
+++ b/common/ECThreadPool.cpp
@@ -123,7 +123,6 @@ void ECThreadPool::setThreadCount(unsigned ulThreadCount, bool bWait)
 					/* If there were no resources, stop trying. */
 					break;
 				}
-				set_thread_name(hThread, "ECThreadPool");
 				m_setThreads.emplace(hThread);
 			}
 		}
@@ -193,6 +192,7 @@ void ECThreadPool::joinTerminated(ulock_normal &locker)
 void* ECThreadPool::threadFunc(void *lpVoid)
 {
 	auto lpPool = static_cast<ECThreadPool *>(lpVoid);
+	set_thread_name(pthread_self(), "ECThreadPool");
 
 	while (true) {
 		STaskInfo sTaskInfo{};

--- a/doc/kopano-dagent.cfg.5
+++ b/doc/kopano-dagent.cfg.5
@@ -311,9 +311,16 @@ Default:
 .SS forward_whitelist_domains
 .PP
 A list of space\-separated domains to which forwarding via a rule is allowed. The "*" matches zero or more characters (including dots, i.e. subdomains at multiple levels). Do not use "*kopano.com" to permit both "@kopano.com" and "@sub.kopano.com", as that would also allow "@notkopano.com".
+There is an implementation-specific limitation of 1024 characters.
 .PP
 Default:
 \fI*\fR
+.SS forward_whitelist_domains_file
+.PP
+This directive overrides forward_whitelist_domains and sources domains from the
+specified file instead.
+.PP
+Default: \fI(empty)\fP
 .SS forward_whitelist_domain_subject
 .PP
 A custom-defined reply subject to the user with a rule forwarding to a
@@ -324,10 +331,17 @@ Default:
 .SS forward_whitelist_domain_message
 .PP
 A custom-defined reply message to the user with a rule forwarding to a
- domain not in forward_whitelist_domains.
+domain not in forward_whitelist_domains. There is no way to specify
+newlines.
 .PP
 Default:
 \fIThe Kopano mail system has rejected your request to forward your e-mail with subject %subject (via mail filters) to %sender: the operation is not permitted.\\n\\nRemove the rule or contact your administrator about the forward_whitelist_domains setting.\fR
+.SS forward_whitelist_domain_message_file
+.PP
+This directive overrides forward_whitelist_domain_message and sources the
+message from the specified file instead.
+.PP
+Default: \fI(empty)\fP
 .SS unknown_charset_substitution
 .PP
 A space-separated list of pairs of space-separated charset name and replacement

--- a/php-ext/ECImportContentsChangesProxy.cpp
+++ b/php-ext/ECImportContentsChangesProxy.cpp
@@ -103,7 +103,7 @@ HRESULT ECImportContentsChangesProxy::Config(LPSTREAM lpStream, ULONG ulFlags) {
     MAKE_STD_ZVAL(pvalArgs[1]);
 	if (lpStream != nullptr) {
 		ZEND_REGISTER_RESOURCE(pvalArgs[0], lpStream, le_istream);
-		if (Z_RESVAL_P(pvalArgs[0]) != nullptr)
+		if (Z_RESVAL_P(pvalArgs[0]))
 			lpStream->AddRef();
 	} else {
 		ZVAL_NULL(pvalArgs[0]);
@@ -144,7 +144,7 @@ HRESULT ECImportContentsChangesProxy::UpdateState(LPSTREAM lpStream) {
 	MAKE_STD_ZVAL(pvalArgs);
 	if (lpStream != nullptr) {
 		ZEND_REGISTER_RESOURCE(pvalArgs, lpStream, le_istream);
-		if (Z_RESVAL_P(pvalArgs) != nullptr)
+		if (Z_RESVAL_P(pvalArgs))
 			lpStream->AddRef();
 	} else {
 		ZVAL_NULL(pvalArgs);

--- a/php-ext/ECImportHierarchyChangesProxy.cpp
+++ b/php-ext/ECImportHierarchyChangesProxy.cpp
@@ -103,7 +103,7 @@ HRESULT ECImportHierarchyChangesProxy::Config(LPSTREAM lpStream, ULONG ulFlags) 
     MAKE_STD_ZVAL(pvalArgs[1]);
 	if (lpStream != nullptr) {
 		ZEND_REGISTER_RESOURCE(pvalArgs[0], lpStream, le_istream);
-		if (Z_RESVAL_P(pvalArgs[0]) != nullptr)
+		if (Z_RESVAL_P(pvalArgs[0]))
 			lpStream->AddRef();
 	} else {
 		ZVAL_NULL(pvalArgs[0]);

--- a/php-ext/main.h
+++ b/php-ext/main.h
@@ -23,11 +23,6 @@
 ***************************************************************/
 #include "globals.h"
 
-struct zvalplus : public zval {
-	zvalplus() { ZVAL_NULL(this); }
-	~zvalplus() { zval_ptr_dtor(this); }
-};
-
 /**
 * Numeric identifier for the resource type
 *

--- a/php7-ext/typeconversion.h
+++ b/php7-ext/typeconversion.h
@@ -16,6 +16,11 @@ ZEND_EXTERN_MODULE_GLOBALS(mapi)
 #include <kopano/charset/convert.h>
 #include <inetmapi/options.h>
 
+struct zvalplus : public zval {
+	zvalplus() { ZVAL_NULL(this); }
+	~zvalplus() { zval_ptr_dtor(this); }
+};
+
 /*
  * PHP -> MAPI
  *

--- a/provider/client/ECMAPIProp.cpp
+++ b/provider/client/ECMAPIProp.cpp
@@ -221,7 +221,7 @@ HRESULT	ECMAPIProp::DefaultMAPIGetProp(ULONG ulPropTag, void* lpProvider, ULONG 
 			if (hr != hrSuccess)
 				return hr;
 		}
-		if (lpProp->m_sMapiObject->ulObjId > 0) {
+		if (lpProp->m_sMapiObject != nullptr && lpProp->m_sMapiObject->ulObjId > 0) {
 			lpsPropValue->ulPropTag = ulPropTag;
 			lpsPropValue->Value.ul = lpProp->m_sMapiObject->ulObjId;
 		} else {

--- a/provider/libserver/ECStoreObjectTable.cpp
+++ b/provider/libserver/ECStoreObjectTable.cpp
@@ -322,7 +322,7 @@ ECRESULT ECStoreObjectTable::QueryRowData(ECGenericObjectTable *lpThis,
 
             // Handle category header rows
             if (row.ulObjId == 0) {
-		if (lpThis->GetPropCategory(soap, lpsPropTagArray->__ptr[k], row, &lpsRowSet->__ptr[i].__ptr[k]) != erSuccess) {
+				if (lpThis == nullptr || lpThis->GetPropCategory(soap, lpsPropTagArray->__ptr[k], row, &lpsRowSet->__ptr[i].__ptr[k]) != erSuccess) {
             		// Other properties are not found
             		lpsRowSet->__ptr[i].__ptr[k].__union = SOAP_UNION_propValData_ul;
             		lpsRowSet->__ptr[i].__ptr[k].Value.ul = KCERR_NOT_FOUND;
@@ -341,7 +341,7 @@ ECRESULT ECStoreObjectTable::QueryRowData(ECGenericObjectTable *lpThis,
 
 			// Handle PR_DEPTH
 			if(ulPropTag == PR_DEPTH) {
-				if (lpThis->GetComputedDepth(soap, lpSession, row.ulObjId, &lpsRowSet->__ptr[i].__ptr[k]) != erSuccess) {
+				if (lpThis == nullptr || lpThis->GetComputedDepth(soap, lpSession, row.ulObjId, &lpsRowSet->__ptr[i].__ptr[k]) != erSuccess) {
 					lpsRowSet->__ptr[i].__ptr[k].__union = SOAP_UNION_propValData_ul;
 					lpsRowSet->__ptr[i].__ptr[k].ulPropTag = PR_DEPTH;
 					lpsRowSet->__ptr[i].__ptr[k].Value.ul = 0;

--- a/spooler/DAgent.cpp
+++ b/spooler/DAgent.cpp
@@ -3215,12 +3215,12 @@ int main(int argc, char **argv) try {
 		{"statsclient_interval", "0", CONFIGSETTING_RELOADABLE},
 		{"statsclient_ssl_verify", "yes", CONFIGSETTING_RELOADABLE},
 		{ "tmp_path", "/tmp" },
-		{"forward_whitelist_domains", "*"},
+		{"forward_whitelist_domains", "*", CONFIGSETTING_RELOADABLE},
 		{"forward_whitelist_domain_message", "The Kopano mail system has rejected your "
 		 "request to forward your e-mail with subject \"%subject\" (via mail filters) "
 		 "to %sender: the operation is not permitted.\n\nRemove the rule or contact "
-		 "your administrator about the forward_whitelist_domains setting.\n"},
-		{"forward_whitelist_domain_subject", "REJECT: %subject not forwarded (administratively blocked)"},
+		 "your administrator about the forward_whitelist_domains setting.\n", CONFIGSETTING_RELOADABLE},
+		{"forward_whitelist_domain_subject", "REJECT: %subject not forwarded (administratively blocked)", CONFIGSETTING_RELOADABLE},
 		{"html_safety_filter", "no"},
 		{"unknown_charset_substitutions", ""},
 		{"indexed_headers", ""},

--- a/spooler/DAgent.cpp
+++ b/spooler/DAgent.cpp
@@ -3216,10 +3216,12 @@ int main(int argc, char **argv) try {
 		{"statsclient_ssl_verify", "yes", CONFIGSETTING_RELOADABLE},
 		{ "tmp_path", "/tmp" },
 		{"forward_whitelist_domains", "*", CONFIGSETTING_RELOADABLE},
+		{"forward_whitelist_domains_file", "", CONFIGSETTING_RELOADABLE},
 		{"forward_whitelist_domain_message", "The Kopano mail system has rejected your "
 		 "request to forward your e-mail with subject \"%subject\" (via mail filters) "
 		 "to %sender: the operation is not permitted.\n\nRemove the rule or contact "
 		 "your administrator about the forward_whitelist_domains setting.\n", CONFIGSETTING_RELOADABLE},
+		{"forward_whitelist_domain_message_file", "", CONFIGSETTING_RELOADABLE},
 		{"forward_whitelist_domain_subject", "REJECT: %subject not forwarded (administratively blocked)", CONFIGSETTING_RELOADABLE},
 		{"html_safety_filter", "no"},
 		{"unknown_charset_substitutions", ""},

--- a/spooler/rules.cpp
+++ b/spooler/rules.cpp
@@ -26,6 +26,7 @@
 #include <kopano/mapiguidext.h>
 #include <kopano/charset/convert.h>
 #include <kopano/IECInterfaces.hpp>
+#include <kopano/fileutil.hpp>
 #include "PyMapiPlugin.h"
 
 using namespace KC;
@@ -63,6 +64,12 @@ class kc_icase_equal {
 	{
 		return strcasecmp(a.c_str(), b.c_str()) == 0;
 	}
+};
+
+struct wlparam {
+	/* Because wildcards are possible, a search tree (map) does not help over vector. */
+	std::vector<std::string> domains;
+	std::wstring subject, body;
 };
 
 /**
@@ -478,14 +485,55 @@ static bool proc_fwd_allowed(const std::vector<std::string> &wdomlist,
 	return false;
 }
 
+static std::string wlparam_slurp(const char *file)
+{
+	std::string content;
+	std::unique_ptr<FILE, file_deleter> fp(fopen(file, "r"));
+	if (fp == nullptr) {
+		ec_log_err("Could not read %s: %s", file, strerror(errno));
+		return content;
+	}
+	auto ret = HrMapFileToString(fp.get(), &content);
+	if (ret != hrSuccess)
+		ec_log_err("HrMapFileToString %s: %s", file, GetMAPIErrorMessage(ret));
+	return content;
+}
+
+static wlparam wlparam_read(ECConfig *cfg)
+{
+	wlparam par;
+	auto z = cfg->GetSetting("forward_whitelist_domains_file");
+        if (z != nullptr && strlen(*z)) {
+		par.domains = tokenize(wlparam_slurp(z), "\t\n ");
+	} else {
+		z = cfg->GetSetting("forward_whitelist_domains");
+		if (z != nullptr)
+			par.domains = tokenize(z, "\t ");
+	}
+	z = cfg->GetSetting("forward_whitelist_domain_message_file");
+	if (z != nullptr && strlen(*z)) {
+		par.body = convert_to<std::wstring>(wlparam_slurp(z));
+	} else {
+		z = cfg->GetSetting("forward_whitelist_domain_message");
+		if (z != nullptr)
+			par.body = convert_to<std::wstring>(z);
+	}
+	z = cfg->GetSetting("forward_whitelist_domain_subject");
+	if (z != nullptr)
+		par.subject = convert_to<std::wstring>(z);
+	return par;
+}
+
 /**
  * @inbox:	folder to dump warning mail into
  * @addr:	target address which delivery was rejected to
+ * @subject:	original message's subject
  *
  * Drop an additional message into @inbox informing about the
  * unwillingness to process a forwarding rule.
  */
-static HRESULT kc_send_fwdabort_notice(IMsgStore *store, const wchar_t *addr, const wchar_t *subject)
+static HRESULT kc_send_fwdabort_notice(IMsgStore *store, const wchar_t *addr,
+    const wchar_t *subject, const wlparam &wlp)
 {
 	memory_ptr<ENTRYID> eid;
 	ULONG eid_size;
@@ -507,7 +555,7 @@ static HRESULT kc_send_fwdabort_notice(IMsgStore *store, const wchar_t *addr, co
 	prop[nprop].ulPropTag = PR_SENDER_NAME_W;
 	prop[nprop++].Value.lpszW = const_cast<wchar_t *>(L"Mail Delivery System");
 
-	auto newsubject = convert_to<std::wstring>(g_lpConfig->GetSetting("forward_whitelist_domain_subject"));
+	auto newsubject = wlp.subject;
 	auto pos = newsubject.find(L"%subject");
 	if (pos != std::string::npos)
 		newsubject = newsubject.replace(pos, 8, subject);
@@ -525,7 +573,7 @@ static HRESULT kc_send_fwdabort_notice(IMsgStore *store, const wchar_t *addr, co
 	prop[nprop].ulPropTag = PR_MESSAGE_DELIVERY_TIME;
 	prop[nprop++].Value.ft = ft;
 
-	auto newbody = convert_to<std::wstring>(g_lpConfig->GetSetting("forward_whitelist_domain_message"));
+	auto newbody = wlp.body;
 	pos = newbody.find(L"%subject");
 	if (pos != std::string::npos)
 		newbody = newbody.replace(pos, 8, subject);
@@ -578,8 +626,7 @@ static HRESULT CheckRecipients(IAddrBook *lpAdrBook, IMsgStore *orig_store,
 		return kc_perrorf("MAPIAllocateBuffer failed", hr);
 
 	lpRecipients->cEntries = 0;
-	std::vector<std::string> fwd_whitelist =
-		tokenize(g_lpConfig->GetSetting("forward_whitelist_domains"), " ");
+	auto wlparam = wlparam_read(g_lpConfig.get());
 	if (HrGetOneProp(lpMessage, PR_MESSAGE_CLASS_A, &~lpMsgClass) != hrSuccess)
 		/* ignore error - will check for pointer instead */;
 
@@ -601,8 +648,9 @@ static HRESULT CheckRecipients(IAddrBook *lpAdrBook, IMsgStore *orig_store,
 		else if (hr != MAPI_E_NOT_FOUND)
 			return hr;
 
-		if (!proc_fwd_allowed(fwd_whitelist, rule_addr_std.c_str())) {
-			kc_send_fwdabort_notice(orig_store, strRuleAddress.c_str(), subject_wstd.c_str());
+		if (!proc_fwd_allowed(wlparam.domains, rule_addr_std.c_str())) {
+			kc_send_fwdabort_notice(orig_store, strRuleAddress.c_str(),
+				subject_wstd.c_str(), wlparam);
 			return MAPI_E_NO_ACCESS;
 		}
 		if (strFromAddress == strRuleAddress &&


### PR DESCRIPTION
Commit 88755037a1d breaks dagent's option "forward_whitelist_domains":
Dagent always tries to read wl-options from a file as it only checks existance of corresponding config-key "forward_whitelist_domains_files", but not its (empty) contents. Thus, forward_whitelist_domains values will never apply even if no whitelist-domain-file is configured (default).