### PR TITLE
dagent: FIX: rules.cpp: wlparam_read always trying to read forward_whitelist_domains_file even if none was specified.

### DIFF
--- a/doc/hl.txt
+++ b/doc/hl.txt
@@ -143,9 +143,9 @@ the unique_tie function makes it possible to do without the explicit temporary
 There are three extra typedefs for the purpose of portraying the "individual
 allocation" strategy often used for ADRLIST, SRowSet and ROWLIST:
 
-	typedef memory_ptr<ADRLIST, rowlist_delete> adrlist_ptr;
-	typedef memory_ptr<SRowSet, rowlist_delete> rowset_ptr;
-	typedef memory_ptr<ROWLIST, rowlist_delete> rowlist_ptr;
+	typedef memory_ptr<ADRLIST, rowset_delete> adrlist_ptr;
+	typedef memory_ptr<SRowSet, rowset_delete> rowset_ptr;
+	typedef memory_ptr<ROWLIST, rowset_delete> rowlist_ptr;
 
 (https://msdn.microsoft.com/en-us/library/office/cc842180.aspx) When every
 SPropValue within such a type is allocated independently — with

--- a/php-ext/main.cpp
+++ b/php-ext/main.cpp
@@ -4267,16 +4267,10 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 		goto exit;
 
 	data = HASH_OF(array);
-	if (zend_hash_find(data, "usedefault", sizeof("usedefault"), (void**)&value) == SUCCESS) {
-		convert_to_boolean_ex(value);
-		lpQuota->bUseDefaultQuota = Z_BVAL_PP(value);
-	}
-
-	if (zend_hash_find(data, "isuserdefault", sizeof("isuserdefault"), (void**)&value) == SUCCESS) {
-		convert_to_boolean_ex(value);
-		lpQuota->bIsUserDefaultQuota = Z_BVAL_PP(value);
-	}
-
+	if (zend_hash_find(data, "usedefault", sizeof("usedefault"), reinterpret_cast<void **>(&value)) == SUCCESS)
+		lpQuota->bUseDefaultQuota = zval_is_true(*value);
+	if (zend_hash_find(data, "isuserdefault", sizeof("isuserdefault"), reinterpret_cast<void **>(&value)) == SUCCESS)
+		lpQuota->bIsUserDefaultQuota = zval_is_true(*value);
 	if (zend_hash_find(data, "warnsize", sizeof("warnsize"), (void**)&value) == SUCCESS) {
 		convert_to_long_ex(value);
 		lpQuota->llWarnSize = Z_LVAL_PP(value);

--- a/php-ext/main.cpp
+++ b/php-ext/main.cpp
@@ -4278,8 +4278,6 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 		goto exit;
 
 	data = HASH_OF(array);
-	zend_hash_internal_pointer_reset(data);
-
 	if (zend_hash_find(data, "usedefault", sizeof("usedefault"), (void**)&value) == SUCCESS) {
 		convert_to_boolean_ex(value);
 		lpQuota->bUseDefaultQuota = Z_BVAL_PP(value);
@@ -5556,8 +5554,6 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 
 		// null pointer returned if perms was not array(array()).
 		data = HASH_OF(entry[0]);
-		zend_hash_internal_pointer_reset(data);
-
 		if (zend_hash_find(data, "userid", sizeof("userid"), (void **)&value) != SUCCESS)
 			continue;
 		convert_to_string_ex(value);
@@ -6124,8 +6120,6 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 		zend_hash_get_current_data(target_hash, (void **) &entry);
 
 		data = HASH_OF(entry[0]);
-		zend_hash_internal_pointer_reset(data);
-
 		if (zend_hash_find(data, "start", sizeof("start"), reinterpret_cast<void **>(&value)) != SUCCESS) {
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;

--- a/php-ext/main.cpp
+++ b/php-ext/main.cpp
@@ -3053,8 +3053,6 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 	zval	*guidArray		= NULL;
 	// return value
 	memory_ptr<SPropTagArray> lpPropTagArray;
-	// local
-	int hashTotal = 0, i = 0;
 	memory_ptr<MAPINAMEID *> lppNamePropId;
 	zval		**entry = NULL, **guidEntry = NULL;
 	HashTable	*targetHash	= NULL,	*guidHash = NULL;
@@ -3074,8 +3072,7 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 		guidHash = Z_ARRVAL_P(guidArray);
 
 	// get the number of items in the array
-	hashTotal = zend_hash_num_elements(targetHash);
-
+	auto hashTotal = zend_hash_num_elements(targetHash);
 	if (guidHash && hashTotal != zend_hash_num_elements(guidHash))
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "The array with the guids is not of the same size as the array with the ids");
 
@@ -3088,7 +3085,7 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 	zend_hash_internal_pointer_reset_ex(targetHash, &thpos);
 	if(guidHash)
 		zend_hash_internal_pointer_reset_ex(guidHash, &ghpos);
-	for (i = 0; i < hashTotal; ++i) {
+	for (unsigned int i = 0; i < hashTotal; ++i) {
 		zend_hash_get_current_data_ex(targetHash, reinterpret_cast<void **>(&entry), &thpos);
 		if(guidHash)
 			zend_hash_get_current_data_ex(guidHash, reinterpret_cast<void **>(&guidEntry), &ghpos);
@@ -3101,7 +3098,7 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 
 		if(guidHash) {
 			if (guidEntry[0]->type != IS_STRING || sizeof(GUID) != guidEntry[0]->value.str.len) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "The GUID with index number %d that is passed is not of the right length, cannot convert to GUID", i);
+				php_error_docref(nullptr TSRMLS_CC, E_WARNING, "The GUID with index number %u that is passed is not of the right length, cannot convert to GUID", i);
 			} else {
 				MAPI_G(hr) = KAllocCopy(guidEntry[0]->value.str.val, sizeof(GUID), reinterpret_cast<void **>(&lppNamePropId[i]->lpguid), lppNamePropId);
 				if (MAPI_G(hr) != hrSuccess)
@@ -5657,7 +5654,6 @@ ZEND_FUNCTION(mapi_freebusysupport_loaddata)
 	PMEASURE_FUNC;
 	LOG_BEGIN();
 	HashTable*			target_hash = NULL;
-	ULONG				i, j;
 	zval**				entry = NULL;
 	int					rid = 0;
 	memory_ptr<FBUser> lpUsers;
@@ -5689,7 +5685,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loaddata)
 		goto exit;
 
 	// Get the user entryids
-	for (j = 0, i = 0; i < cUsers; ++i) {
+	for (unsigned int j = 0, i = 0; i < cUsers; ++i) {
 		if (zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos) == FAILURE) {
 			MAPI_G(hr) = MAPI_E_INVALID_ENTRYID;
 			goto exit;
@@ -5711,7 +5707,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loaddata)
 
 	//Return an array of IFreeBusyData interfaces
 	array_init(return_value);
-	for (i = 0; i < cUsers; ++i) {
+	for (unsigned int i = 0; i < cUsers; ++i) {
 		if(lppFBData[i])
 		{
 			// Set resource relation
@@ -5736,7 +5732,6 @@ ZEND_FUNCTION(mapi_freebusysupport_loadupdate)
 	PMEASURE_FUNC;
 	LOG_BEGIN();
 	HashTable*			target_hash = NULL;
-	ULONG				i, j;
 	zval**				entry = NULL;
 	int					rid = 0;
 	memory_ptr<FBUser> lpUsers;
@@ -5768,7 +5763,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loadupdate)
 		goto exit;
 
 	// Get the user entryids
-	for (j = 0, i = 0; i < cUsers; ++i) {
+	for (unsigned int j = 0, i = 0; i < cUsers; ++i) {
 		if (zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos) == FAILURE)
 		{
 			MAPI_G(hr) = MAPI_E_INVALID_ENTRYID;
@@ -5791,7 +5786,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loadupdate)
 
 	//Return an array of IFreeBusyUpdate interfaces
 	array_init(return_value);
-	for (i = 0; i < cUsers; ++i) {
+	for (unsigned int i = 0; i < cUsers; ++i) {
 		if(lppFBUpdate[i])
 		{
 			// Set resource relation
@@ -6086,7 +6081,6 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 	memory_ptr<FBBlock_1> lpBlocks;
 	ULONG				cBlocks = 0;
 	HashTable*			target_hash = NULL;
-	ULONG				i;
 	zval**				entry = NULL;
 	zval**				value = NULL;
 	HashTable*			data = NULL;
@@ -6111,7 +6105,7 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 	if(MAPI_G(hr) != hrSuccess)
 		goto exit;
 
-	for (i = 0; i < cBlocks; ++i) {
+	for (unsigned int i = 0; i < cBlocks; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		data = HASH_OF(entry[0]);
 		if (zend_hash_find(data, "start", sizeof("start"), reinterpret_cast<void **>(&value)) != SUCCESS) {

--- a/php-ext/main.cpp
+++ b/php-ext/main.cpp
@@ -4272,16 +4272,19 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 	if (zend_hash_find(data, "isuserdefault", sizeof("isuserdefault"), reinterpret_cast<void **>(&value)) == SUCCESS)
 		lpQuota->bIsUserDefaultQuota = zval_is_true(*value);
 	if (zend_hash_find(data, "warnsize", sizeof("warnsize"), (void**)&value) == SUCCESS) {
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpQuota->llWarnSize = Z_LVAL_PP(value);
 	}
 
 	if (zend_hash_find(data, "softsize", sizeof("softsize"), (void**)&value) == SUCCESS) {
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpQuota->llSoftSize = Z_LVAL_PP(value);
 	}
 
 	if (zend_hash_find(data, "hardsize", sizeof("hardsize"), (void**)&value) == SUCCESS) {
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpQuota->llHardSize = Z_LVAL_PP(value);
 	}
@@ -5538,21 +5541,25 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 		data = HASH_OF(entry[0]);
 		if (zend_hash_find(data, "userid", sizeof("userid"), (void **)&value) != SUCCESS)
 			continue;
+		SEPARATE_ZVAL(value);
 		convert_to_string_ex(value);
 		lpECPerms[j].sUserId.cb = Z_STRLEN_PP(value);
 		lpECPerms[j].sUserId.lpb = (unsigned char*)Z_STRVAL_PP(value);
 
 		if (zend_hash_find(data, "type", sizeof("type"), (void **)&value) != SUCCESS)
 			continue;
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpECPerms[j].ulType = Z_LVAL_PP(value);
 
 		if (zend_hash_find(data, "rights", sizeof("rights"), (void **)&value) != SUCCESS)
 			continue;
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpECPerms[j].ulRights = Z_LVAL_PP(value);
 
 		if (zend_hash_find(data, "state", sizeof("state"), (void **)&value) == SUCCESS) {
+			SEPARATE_ZVAL(value);
 		    convert_to_long_ex(value);
 			lpECPerms[j].ulState = Z_LVAL_PP(value);
 		} else {

--- a/php-ext/main.cpp
+++ b/php-ext/main.cpp
@@ -3084,18 +3084,14 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 	if (MAPI_G(hr) != hrSuccess)
 		goto exit;
 
-	// first reset the hash, so the pointer points to the first element.
-	zend_hash_internal_pointer_reset(targetHash);
-
+	HashPosition thpos, ghpos;
+	zend_hash_internal_pointer_reset_ex(targetHash, &thpos);
 	if(guidHash)
-		zend_hash_internal_pointer_reset(guidHash);
-
+		zend_hash_internal_pointer_reset_ex(guidHash, &ghpos);
 	for (i = 0; i < hashTotal; ++i) {
-		//	Gets the element that exist at the current pointer.
-		zend_hash_get_current_data(targetHash,(void **) &entry);
+		zend_hash_get_current_data_ex(targetHash, reinterpret_cast<void **>(&entry), &thpos);
 		if(guidHash)
-			zend_hash_get_current_data(guidHash, (void **) &guidEntry);
-
+			zend_hash_get_current_data_ex(guidHash, reinterpret_cast<void **>(&guidEntry), &ghpos);
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(MAPINAMEID),lppNamePropId,(void **) &lppNamePropId[i]);
 		if (MAPI_G(hr) != hrSuccess)
 			goto exit;
@@ -3136,11 +3132,9 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Entry is of an unknown type: %08X", entry[0]->type);
 			break;
 		}
-
-		// move the pointers of the hashtables forward.
-		zend_hash_move_forward(targetHash);
+		zend_hash_move_forward_ex(targetHash, &thpos);
 		if(guidHash)
-			zend_hash_move_forward(guidHash);
+			zend_hash_move_forward_ex(guidHash, &ghpos);
 	}
 
 	MAPI_G(hr) = lpMessageStore->GetIDsFromNames(hashTotal, lppNamePropId, MAPI_CREATE, &~lpPropTagArray);
@@ -5541,8 +5535,8 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 	}
 
 	// The following code should be in typeconversion.cpp
-
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	cPerms = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPIAllocateBuffer(sizeof(ECPERMISSION)*cPerms, &~lpECPerms);
 	if (MAPI_G(hr) != hrSuccess)
@@ -5550,8 +5544,7 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 	memset(lpECPerms, 0, sizeof(ECPERMISSION)*cPerms);
 	
 	for (j = 0, i = 0; i < cPerms; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		// null pointer returned if perms was not array(array()).
 		data = HASH_OF(entry[0]);
 		if (zend_hash_find(data, "userid", sizeof("userid"), (void **)&value) != SUCCESS)
@@ -5577,7 +5570,7 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 			lpECPerms[j].ulState = RIGHT_NEW|RIGHT_AUTOUPDATE_DENIED;
 		}
 		++j;
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	MAPI_G(hr) = lpSecurity->SetPermissionRules(j, lpECPerms);
@@ -5688,7 +5681,8 @@ ZEND_FUNCTION(mapi_freebusysupport_loaddata)
 		goto exit;
 	}
 
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	cUsers = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPIAllocateBuffer(sizeof(FBUser)*cUsers, &~lpUsers);
 	if(MAPI_G(hr) != hrSuccess)
@@ -5696,8 +5690,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loaddata)
 
 	// Get the user entryids
 	for (j = 0, i = 0; i < cUsers; ++i) {
-		if(zend_hash_get_current_data(target_hash, (void **) &entry) == FAILURE)
-		{
+		if (zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos) == FAILURE) {
 			MAPI_G(hr) = MAPI_E_INVALID_ENTRYID;
 			goto exit;
 		}
@@ -5705,7 +5698,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loaddata)
 		lpUsers[j].m_cbEid = Z_STRLEN_PP(entry);
 		lpUsers[j].m_lpEid = (LPENTRYID)Z_STRVAL_PP(entry);
 		++j;
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	MAPI_G(hr) = MAPIAllocateBuffer(sizeof(IFreeBusyData*)*cUsers, (void**)&lppFBData);
@@ -5767,7 +5760,8 @@ ZEND_FUNCTION(mapi_freebusysupport_loadupdate)
 		goto exit;
 	}
 
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	cUsers = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPIAllocateBuffer(sizeof(FBUser)*cUsers, &~lpUsers);
 	if(MAPI_G(hr) != hrSuccess)
@@ -5775,7 +5769,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loadupdate)
 
 	// Get the user entryids
 	for (j = 0, i = 0; i < cUsers; ++i) {
-		if(zend_hash_get_current_data(target_hash, (void **) &entry) == FAILURE)
+		if (zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos) == FAILURE)
 		{
 			MAPI_G(hr) = MAPI_E_INVALID_ENTRYID;
 			goto exit;
@@ -5784,7 +5778,7 @@ ZEND_FUNCTION(mapi_freebusysupport_loadupdate)
 		lpUsers[j].m_cbEid = Z_STRLEN_PP(entry);
 		lpUsers[j].m_lpEid = (LPENTRYID)Z_STRVAL_PP(entry);
 		++j;
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	MAPI_G(hr) = MAPIAllocateBuffer(sizeof(IFreeBusyUpdate*)*cUsers, &~lppFBUpdate);
@@ -6110,15 +6104,15 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 		goto exit;
 	}
 
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	cBlocks = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPIAllocateBuffer(sizeof(FBBlock_1)*cBlocks, &~lpBlocks);
 	if(MAPI_G(hr) != hrSuccess)
 		goto exit;
 
 	for (i = 0; i < cBlocks; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		data = HASH_OF(entry[0]);
 		if (zend_hash_find(data, "start", sizeof("start"), reinterpret_cast<void **>(&value)) != SUCCESS) {
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -6135,7 +6129,7 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 			goto exit;
 		}
 		lpBlocks[i].m_fbstatus = (enum FBStatus)Z_LVAL_PP(value);
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	MAPI_G(hr) = lpFBUpdate->PublishFreeBusy(lpBlocks, cBlocks);

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -93,7 +93,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
@@ -103,7 +103,6 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 		if(MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		++n;
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	lpBinaryArray->cValues = n;
@@ -185,7 +184,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		//todo: check on FAILURE
 		char *key = NULL;
 		ulong ind = 0;
@@ -199,7 +198,6 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 
 		convert_to_long_ex(&entry[0]);
 		lpSortOrderSet->aSort[i].ulOrder = (ULONG) entry[0]->value.lval;
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lppSortOrderSet = lpSortOrderSet;
@@ -233,12 +231,11 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		convert_to_long_ex(entry);
 
 		lpPropTagArray->aulPropTag[i] = entry[0]->value.lval;
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	
 	*lppPropTagArray = lpPropTagArray;
@@ -291,7 +288,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			MAPIFreeBuffer(lpPropValue);
 	});
 
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &thpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &thpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &thpos);
 
@@ -388,11 +385,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	CHECK_EMPTY_MV_ARRAY(mapimvmember, mapilpmember) \
 	lpPropValue[cvalues].Value.mapimvmember.cValues = countarray; \
 	MAPI_G(hr) = MAPIAllocateMore(sizeof(lpPropValue[cvalues].Value.mapimvmember.mapilpmember[0]) * countarray, lpBase ? lpBase : lpPropValue, (void**)&lpPropValue[cvalues].Value.mapimvmember.mapilpmember); \
-	for (j = 0; j < countarray; ++j) { \
+	for (j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &dhpos)) { \
 		zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos); \
 		convert_to_##type##_ex(dataEntry); \
 		lpPropValue[cvalues].Value.mapimvmember.mapilpmember[j] = dataEntry[0]->value.phpmember; \
-		zend_hash_move_forward_ex(dataHash, &dhpos); \
 	}
 
 		case PT_MV_I2:
@@ -422,11 +418,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			lpPropValue[cvalues].Value.MVft.cValues = countarray;
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(FILETIME) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVft.lpft)) != hrSuccess)
 				return MAPI_G(hr);
-			for (j = 0; j < countarray; ++j) {
+			for (j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_long_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVft.lpft[j] = UnixTimeToFileTime(dataEntry[0]->value.lval);
-				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			++cvalues;
 			break;
@@ -436,7 +431,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			CHECK_EMPTY_MV_ARRAY(MVbin, lpbin);
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(SBinary) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVbin.lpbin)) != hrSuccess)
 				return MAPI_G(hr);
-			for (h = 0, j = 0; j < countarray; ++j) {
+			for (h = 0, j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_string_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVbin.lpbin[h].cb = dataEntry[0]->value.str.len;
@@ -444,7 +439,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				if (MAPI_G(hr) != hrSuccess)
 					return MAPI_G(hr);
 				++h;
-				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			lpPropValue[cvalues++].Value.MVbin.cValues = h;
 			break;
@@ -453,14 +447,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			CHECK_EMPTY_MV_ARRAY(MVszA, lppszA);
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(char*) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA)) != hrSuccess)
 				return MAPI_G(hr);
-			for (h = 0, j = 0; j < countarray; ++j) {
+			for (h = 0, j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_string_ex(dataEntry);
 				MAPI_G(hr) = KAllocCopy(dataEntry[0]->value.str.val, dataEntry[0]->value.str.len + 1, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVszA.lppszA[h]), lpBase != nullptr ? lpBase : lpPropValue);
 				if (MAPI_G(hr) != hrSuccess)
 					return MAPI_G(hr);
 				++h;
-				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			lpPropValue[cvalues++].Value.MVszA.cValues = h;
 			break;
@@ -469,14 +462,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			CHECK_EMPTY_MV_ARRAY(MVguid, lpguid);
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(GUID) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVguid.lpguid)) != hrSuccess)
 				return MAPI_G(hr);
-			for (h = 0, j = 0; j < countarray; ++j) {
+			for (h = 0, j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_string_ex(dataEntry);
 				if (dataEntry[0]->value.str.len != sizeof(GUID))
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "invalid value for PT_MV_CLSID property in proptag 0x%08X, position %d,%d", lpPropValue[cvalues].ulPropTag, i, j);
 				else
 					memcpy(&lpPropValue[cvalues].Value.MVguid.lpguid[h++], dataEntry[0]->value.str.val, sizeof(GUID));
-				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			lpPropValue[cvalues++].Value.MVguid.cValues = h;
 			break;
@@ -505,7 +497,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			memset(lpActions->lpAction, 0, sizeof(ACTION) * lpActions->cActions);
 
-			for (j = 0; j < countarray; ++j) {
+			for (j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&entry), &dhpos);
 				actionHash = HASH_OF(entry[0]);
 				if (!actionHash) {
@@ -635,7 +627,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					// Nothing to do
 					break;
 				};
-				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			++cvalues;
 			break;
@@ -656,7 +647,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown property type %08X", PROP_TYPE(numIndex));
 			return MAPI_G(hr) = MAPI_E_INVALID_TYPE;
 		}
-		zend_hash_move_forward_ex(target_hash, &thpos);
 	}
 
 	*lpcValues = cvalues;
@@ -704,7 +694,7 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 	// FIXME: It is possible that the memory allocated is more than actually needed. We should first
 	//		  count the number of elements needed then allocate memory and then fill the memory.
 	//        but since this waste is probably very minimal, we could not care less about this.
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		if(entry[0]->type != IS_ARRAY) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "phparraytoadrlist array must include an array with array of propvalues");
@@ -719,7 +709,6 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 		lpAdrList->aEntries[countRecipients].ulReserved1 = 0;
 		lpAdrList->aEntries[countRecipients].rgPropVals = pPropValue;
 		lpAdrList->aEntries[countRecipients].cValues = countProperties;
-		zend_hash_move_forward_ex(target_hash, &hpos);
 		++countRecipients;
 	}
 	*lppAdrList = lpAdrList;
@@ -762,7 +751,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	// FIXME: It is possible that the memory allocated is more than actually needed. We should first
 	//		  count the number of elements needed then allocate memory and then fill the memory.
 	//        but since this waste is probably very minimal, we could not care less about this.
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		if (Z_TYPE_PP(entry) != IS_ARRAY) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, Row not wrapped in array");
@@ -796,7 +785,6 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	*lppRowList = lpRowList.release();
 exit:
@@ -915,13 +903,12 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(SRestriction) * count, lpBase, (void **) &lpRes->res.resAnd.lpRes);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
-		for (unsigned int i = 0; i < count; ++i) {
+		for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 			zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, &lpRes->res.resAnd.lpRes[i] TSRMLS_CC);
 			
 			if (MAPI_G(hr) != hrSuccess)
 				return MAPI_G(hr);
-			zend_hash_move_forward_ex(dataHash, &dhpos);
 		}
 		break;
 	case RES_OR:
@@ -931,13 +918,12 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 
-		for (unsigned int i = 0; i < count; ++i) {
+		for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(dataHash, &dhpos)) {
 			zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, &lpRes->res.resOr.lpRes[i] TSRMLS_CC);
 
 			if (MAPI_G(hr) != hrSuccess)
 				return MAPI_G(hr);
-			zend_hash_move_forward_ex(dataHash, &dhpos);
 		}
 		break;
 	case RES_NOT:
@@ -1896,7 +1882,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		return MAPI_G(hr);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
@@ -1909,7 +1895,6 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		}
 		
 		memcpy(&lpGUIDs[n++], pentry->value.str.val, sizeof(GUID));
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lppGUIDs = lpGUIDs;
@@ -2003,7 +1988,7 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	auto count = zend_hash_num_elements(target_hash);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
 
@@ -2035,8 +2020,6 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			// msg_in_msg and enable_dsn not allowed, others unknown
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed sending option %s", keyIndex);
 		}
-
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	return hr;
 }
@@ -2065,7 +2048,7 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	auto count = zend_hash_num_elements(target_hash);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (unsigned int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
 
@@ -2091,8 +2074,6 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 			// user_entryid not supported, others unknown
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed delivery option %s", keyIndex);
 		}
-
-		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	return hr;
 }

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -749,7 +749,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	ULONG			countProperties = 0;		// number of properties
 	ULONG			count = 0;					// number of elements in the array
 	ULONG			countRows = 0;		// number of actual recipients
-	LPROWLIST		lpRowList = NULL;
+	rowlist_ptr lpRowList;
 	zval			**entry = NULL;
 	zval			**data = NULL;
 	LPSPropValue	pPropValue = NULL;
@@ -770,8 +770,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	count = zend_hash_num_elements(target_hash);
 
 	// allocate memory to store the array of pointers
-	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count),
-	             reinterpret_cast<void **>(&lpRowList));
+	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count), &~lpRowList);
 	if (MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 	lpRowList->cEntries = 0;
@@ -817,11 +816,8 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 		}
 		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
-	*lppRowList = lpRowList;
-
+	*lppRowList = lpRowList.release();
 exit:
-	if (MAPI_G(hr) != hrSuccess)
-		FreeProws(reinterpret_cast<SRowSet *>(lpRowList));
 	return MAPI_G(hr);
 }
 

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -189,13 +189,14 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 		char *key = NULL;
 		ulong ind = 0;
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
-		// when the key is a char &key is set else ind is set
-		zend_hash_get_current_key_ex(target_hash, &key, nullptr, &ind, 0, &hpos);
-		if (key != NULL)
+		auto xtype = zend_hash_get_current_key_ex(target_hash, &key,
+		             nullptr, &ind, 0, &hpos);
+		if (xtype == HASH_KEY_IS_STRING)
 			lpSortOrderSet->aSort[i].ulPropTag = atoi(key);
-		else
+		else if (xtype == HASH_KEY_IS_LONG)
 			lpSortOrderSet->aSort[i].ulPropTag = ind;
-
+		else
+			continue;
 		convert_to_long_ex(&entry[0]);
 		lpSortOrderSet->aSort[i].ulOrder = (ULONG) entry[0]->value.lval;
 	}
@@ -252,8 +253,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	ULONG			cvalues = 0;
 	HashTable		*target_hash = NULL;
 	HashTable		*dataHash = NULL;
-	char			*keyIndex;
-	ulong			numIndex = 0;
 	zval			**entry = NULL;
 	ULONG			countarray = 0;
 	zval			**dataEntry = NULL;
@@ -289,10 +288,15 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	});
 
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &thpos)) {
+		char *keyIndex = nullptr;
+		ulong numIndex = 0;
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &thpos);
-		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &thpos);
+		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
+		    nullptr, &numIndex, 0, &thpos) != HASH_KEY_IS_LONG) {
+			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoPropValueArray: expected array to be int-keyed");
+			continue;
+		}
 
-		// assume a numeric index
 		lpPropValue[cvalues].ulPropTag = numIndex;
 		switch(PROP_TYPE(numIndex))	{
 		case PT_SHORT:
@@ -1969,8 +1973,6 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	HRESULT hr = hrSuccess;
 	HashTable		*target_hash = NULL;
 	zval			**entry = NULL;
-	char			*keyIndex;
-	ulong			numIndex = 0;
 
 	if (!phpArray) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoSendingOptions");
@@ -1989,8 +1991,14 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
+		char *keyIndex = nullptr;
+		ulong numIndex = 0;
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
-		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
+		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
+		    nullptr, &numIndex, 0, &hpos) != HASH_KEY_IS_STRING) {
+			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoSendingOptions: expected array to be string-keyed");
+			continue;
+		}
 
 		if (strcmp(keyIndex, "alternate_boundary") == 0) {
 			convert_to_string_ex(entry);
@@ -2029,8 +2037,6 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	HRESULT hr = hrSuccess;
 	HashTable		*target_hash = NULL;
 	zval			**entry = NULL;
-	char			*keyIndex;
-	ulong			numIndex = 0;
 
 	if (!phpArray) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoDeliveryOptions");
@@ -2049,8 +2055,14 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
+		char *keyIndex = nullptr;
+		ulong numIndex = 0;
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
-		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
+		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
+		    nullptr, &numIndex, 0, &hpos) != HASH_KEY_IS_STRING) {
+			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoDeliveryOptions: expected array to be string-keyed");
+			continue;
+		}
 
 		if (strcmp(keyIndex, "use_received_date") == 0) {
 			convert_to_boolean_ex(entry);

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -821,8 +821,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 
 exit:
 	if (MAPI_G(hr) != hrSuccess)
-		MAPIFreeBuffer(lpRowList);
-
+		FreeProws(reinterpret_cast<SRowSet *>(lpRowList));
 	return MAPI_G(hr);
 }
 

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -93,11 +93,10 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 
-	// Reset php pointer
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &ppentry);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
 		convert_to_string_ex(&pentry);
@@ -106,7 +105,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 		if(MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		++n;
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	lpBinaryArray->cValues = n;
@@ -190,17 +189,15 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 	lpSortOrderSet->cCategories = 0;
 	lpSortOrderSet->cExpanded = 0;
 
-	// first reset the hash, so the pointer points to the first element.
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
 		//todo: check on FAILURE
 		char *key = NULL;
 		ulong ind = 0;
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		// when the key is a char &key is set else ind is set
-		zend_hash_get_current_key(target_hash, &key, &ind, 0);
+		zend_hash_get_current_key_ex(target_hash, &key, nullptr, &ind, 0, &hpos);
 		if (key != NULL)
 			lpSortOrderSet->aSort[i].ulPropTag = atoi(key);
 		else
@@ -208,9 +205,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 
 		convert_to_long_ex(&entry[0]);
 		lpSortOrderSet->aSort[i].ulOrder = (ULONG) entry[0]->value.lval;
-
-		// get next hash pointer
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lppSortOrderSet = lpSortOrderSet;
@@ -249,19 +244,14 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 		return MAPI_G(hr);
 	lpPropTagArray->cValues = count;
 
-	// first reset the hash, so the pointer points to the first element.
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
-		//	Gets the element that exist at the current pointer.
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-		
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		convert_to_long_ex(entry);
 
 		lpPropTagArray->aulPropTag[i] = entry[0]->value.lval;
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	
 	*lppPropTagArray = lpPropTagArray;
@@ -310,14 +300,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	    *lpcValues = 0;
 	}
 
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition thpos, dhpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &thpos);
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(SPropValue) * count, lpBase, (void**)&lpPropValue);
 
 	for (int i = 0; i < count; ++i) {
-		//	Gets the element that exist at the current pointer.
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-		zend_hash_get_current_key(target_hash, &keyIndex, &numIndex, 0);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &thpos);
+		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &thpos);
 
 		// assume a numeric index
 		lpPropValue[cvalues].ulPropTag = numIndex;
@@ -404,7 +393,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			lpPropValue[cvalues].Value.mapimvmember.mapilpmember = NULL; \
 			break; \
 		} \
-		zend_hash_internal_pointer_reset(dataHash); \
+		zend_hash_internal_pointer_reset_ex(dataHash, &dhpos); \
 	}
 
 #define COPY_MV_PROPS(type, mapimvmember, mapilpmember, phpmember) \
@@ -413,10 +402,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	lpPropValue[cvalues].Value.mapimvmember.cValues = countarray; \
 	MAPI_G(hr) = MAPIAllocateMore(sizeof(lpPropValue[cvalues].Value.mapimvmember.mapilpmember[0]) * countarray, lpBase ? lpBase : lpPropValue, (void**)&lpPropValue[cvalues].Value.mapimvmember.mapilpmember); \
 	for (j = 0; j < countarray; ++j) { \
-		zend_hash_get_current_data(dataHash, (void **) &dataEntry); \
+		zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos); \
 		convert_to_##type##_ex(dataEntry); \
 		lpPropValue[cvalues].Value.mapimvmember.mapilpmember[j] = dataEntry[0]->value.phpmember; \
-		zend_hash_move_forward(dataHash); \
+		zend_hash_move_forward_ex(dataHash, &dhpos); \
 	}
 
 		case PT_MV_I2:
@@ -447,10 +436,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(FILETIME) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVft.lpft)) != hrSuccess)
 				return MAPI_G(hr);
 			for (j = 0; j < countarray; ++j) {
-				zend_hash_get_current_data(dataHash, (void **)&dataEntry);
+				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_long_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVft.lpft[j] = UnixTimeToFileTime(dataEntry[0]->value.lval);
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			++cvalues;
 			break;
@@ -461,14 +450,14 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(SBinary) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVbin.lpbin)) != hrSuccess)
 				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j) {
-				zend_hash_get_current_data(dataHash, (void **)&dataEntry);
+				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_string_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVbin.lpbin[h].cb = dataEntry[0]->value.str.len;
 				MAPI_G(hr) = KAllocCopy(dataEntry[0]->value.str.val, dataEntry[0]->value.str.len, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVbin.lpbin[h].lpb), lpBase != nullptr ? lpBase : lpPropValue);
 				if (MAPI_G(hr) != hrSuccess)
 					return MAPI_G(hr);
 				++h;
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			lpPropValue[cvalues++].Value.MVbin.cValues = h;
 			break;
@@ -478,13 +467,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(char*) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA)) != hrSuccess)
 				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j) {
-				zend_hash_get_current_data(dataHash, (void **)&dataEntry);
+				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_string_ex(dataEntry);
 				MAPI_G(hr) = KAllocCopy(dataEntry[0]->value.str.val, dataEntry[0]->value.str.len + 1, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVszA.lppszA[h]), lpBase != nullptr ? lpBase : lpPropValue);
 				if (MAPI_G(hr) != hrSuccess)
 					return MAPI_G(hr);
 				++h;
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			lpPropValue[cvalues++].Value.MVszA.cValues = h;
 			break;
@@ -494,13 +483,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(GUID) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVguid.lpguid)) != hrSuccess)
 				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j) {
-				zend_hash_get_current_data(dataHash, (void **)&dataEntry);
+				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&dataEntry), &dhpos);
 				convert_to_string_ex(dataEntry);
 				if (dataEntry[0]->value.str.len != sizeof(GUID))
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "invalid value for PT_MV_CLSID property in proptag 0x%08X, position %d,%d", lpPropValue[cvalues].ulPropTag, i, j);
 				else
 					memcpy(&lpPropValue[cvalues].Value.MVguid.lpguid[h++], dataEntry[0]->value.str.val, sizeof(GUID));
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			lpPropValue[cvalues++].Value.MVguid.cValues = h;
 			break;
@@ -514,7 +503,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			dataHash = HASH_OF(entry[0]);
 			if (!dataHash)
 				break;
-			zend_hash_internal_pointer_reset(dataHash);
+			zend_hash_internal_pointer_reset_ex(dataHash, &dhpos);
 			countarray = zend_hash_num_elements(dataHash); // # of actions
 			if (countarray == 0) {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_ACTIONS is empty");
@@ -530,7 +519,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			memset(lpActions->lpAction, 0, sizeof(ACTION) * lpActions->cActions);
 
 			for (j = 0; j < countarray; ++j) {
-				zend_hash_get_current_data(dataHash, (void **)&entry);
+				zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&entry), &dhpos);
 				actionHash = HASH_OF(entry[0]);
 				if (!actionHash) {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "ACTIONS structure has a wrong ACTION");
@@ -659,7 +648,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					// Nothing to do
 					break;
 				};
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &dhpos);
 			}
 			++cvalues;
 			break;
@@ -680,9 +669,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown property type %08X", PROP_TYPE(numIndex));
 			return MAPI_G(hr) = MAPI_E_INVALID_TYPE;
 		}
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &thpos);
 	}
 
 	*lpcValues = cvalues;
@@ -725,13 +712,14 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 	lpAdrList->cEntries = 0;
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 
 	// FIXME: It is possible that the memory allocated is more than actually needed. We should first
 	//		  count the number of elements needed then allocate memory and then fill the memory.
 	//        but since this waste is probably very minimal, we could not care less about this.
 	for (unsigned int i = 0; i < count; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &entry);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		if(entry[0]->type != IS_ARRAY) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "phparraytoadrlist array must include an array with array of propvalues");
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -745,9 +733,7 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 		lpAdrList->aEntries[countRecipients].ulReserved1 = 0;
 		lpAdrList->aEntries[countRecipients].rgPropVals = pPropValue;
 		lpAdrList->aEntries[countRecipients].cValues = countProperties;
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 		++countRecipients;
 	}
 	*lppAdrList = lpAdrList;
@@ -789,13 +775,14 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	if (MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 	lpRowList->cEntries = 0;
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 
 	// FIXME: It is possible that the memory allocated is more than actually needed. We should first
 	//		  count the number of elements needed then allocate memory and then fill the memory.
 	//        but since this waste is probably very minimal, we could not care less about this.
 	for (unsigned int i = 0; i < count; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &entry);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		if (Z_TYPE_PP(entry) != IS_ARRAY) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, Row not wrapped in array");
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -828,9 +815,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	*lppRowList = lpRowList;
 
@@ -928,12 +913,13 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Wrong array should be array(RES_, array(values))");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	zend_hash_internal_pointer_reset(resHash);
+	HashPosition rhpos, dhpos;
+	zend_hash_internal_pointer_reset_ex(resHash, &rhpos);
 
 	// structure assumption: add more checks that valueEntry becomes php array pointer?
-	zend_hash_get_current_data(resHash, (void **) &typeEntry); // 0=type, 1=array
-	zend_hash_move_forward(resHash);
-	zend_hash_get_current_data(resHash, (void **) &valueEntry);
+	zend_hash_get_current_data_ex(resHash, reinterpret_cast<void **>(&typeEntry), &rhpos); // 0=type, 1=array
+	zend_hash_move_forward_ex(resHash, &rhpos);
+	zend_hash_get_current_data_ex(resHash, reinterpret_cast<void **>(&valueEntry), &rhpos);
 
 	lpRes->rt = typeEntry[0]->value.lval;		// set restriction type (RES_AND, RES_OR, ...)
 	dataHash = HASH_OF(valueEntry[0]);			// from resHash
@@ -942,8 +928,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 	count = zend_hash_num_elements(dataHash);
-
-	zend_hash_internal_pointer_reset(dataHash);
+	zend_hash_internal_pointer_reset_ex(dataHash, &dhpos);
 
 	switch(lpRes->rt) {
 	/*
@@ -956,13 +941,12 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		for (i = 0; i < count; ++i) {
-			zend_hash_get_current_data(dataHash, (void **) &valueEntry);
-
+			zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, &lpRes->res.resAnd.lpRes[i] TSRMLS_CC);
 			
 			if (MAPI_G(hr) != hrSuccess)
 				return MAPI_G(hr);
-			zend_hash_move_forward(dataHash);
+			zend_hash_move_forward_ex(dataHash, &dhpos);
 		}
 		break;
 	case RES_OR:
@@ -973,13 +957,12 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			return MAPI_G(hr);
 
 		for (i = 0; i < count; ++i) {
-			zend_hash_get_current_data(dataHash, (void **) &valueEntry);
-
+			zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, &lpRes->res.resOr.lpRes[i] TSRMLS_CC);
 
 			if (MAPI_G(hr) != hrSuccess)
 				return MAPI_G(hr);
-			zend_hash_move_forward(dataHash);
+			zend_hash_move_forward_ex(dataHash, &dhpos);
 		}
 		break;
 	case RES_NOT:
@@ -987,8 +970,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(SRestriction), lpBase, (void **) &lpRes->res.resNot.lpRes);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
-		zend_hash_get_current_data(dataHash, (void **) &valueEntry);
-
+		zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 		MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, lpRes->res.resNot.lpRes TSRMLS_CC);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
@@ -1874,11 +1856,10 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 	if(MAPI_G(hr) != hrSuccess) 
 		return MAPI_G(hr);
 
-	// Reset php pointer
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &ppentry);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
 		if(zend_hash_find(HASH_OF(pentry), "sourcekey", sizeof("sourcekey"), (void **)&valueEntry) == FAILURE) {
@@ -1944,11 +1925,10 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(GUID) * count, lpBase, (void **) &lpGUIDs);
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
-
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
-		zend_hash_get_current_data(target_hash, (void **) &ppentry);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
 		convert_to_string_ex(&pentry);
@@ -1960,7 +1940,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		}
 		
 		memcpy(&lpGUIDs[n++], pentry->value.str.val, sizeof(GUID));
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lppGUIDs = lpGUIDs;
@@ -2054,11 +2034,11 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	}
 
 	count = zend_hash_num_elements(target_hash);
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
-		// Gets the element that exist at the current pointer.
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-		zend_hash_get_current_key(target_hash, &keyIndex, &numIndex, 0);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
+		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
 
 		if (strcmp(keyIndex, "alternate_boundary") == 0) {
 			convert_to_string_ex(entry);
@@ -2089,7 +2069,7 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed sending option %s", keyIndex);
 		}
 
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	return hr;
 }
@@ -2118,11 +2098,11 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	}
 
 	count = zend_hash_num_elements(target_hash);
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
-		// Gets the element that exist at the current pointer.
-		zend_hash_get_current_data(target_hash, (void **) &entry);
-		zend_hash_get_current_key(target_hash, &keyIndex, &numIndex, 0);
+		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
+		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
 
 		if (strcmp(keyIndex, "use_received_date") == 0) {
 			convert_to_boolean_ex(entry);
@@ -2147,7 +2127,7 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed delivery option %s", keyIndex);
 		}
 
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	return hr;
 }

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -303,6 +303,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	HashPosition thpos, dhpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &thpos);
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(SPropValue) * count, lpBase, (void**)&lpPropValue);
+	auto cleanup = make_scope_success([&]() {
+		if (MAPI_G(hr) != hrSuccess && lpBase != nullptr && lpPropValue != nullptr)
+			MAPIFreeBuffer(lpPropValue);
+	});
 
 	for (int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &thpos);

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -320,9 +320,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			lpPropValue[cvalues++].Value.li.QuadPart = (LONGLONG)entry[0]->value.dval;
 			break;
 		case PT_BOOLEAN:
-			convert_to_boolean_ex(entry);
-			// lval will be 1 or 0 for true or false
-			lpPropValue[cvalues++].Value.b = (unsigned short)entry[0]->value.lval;
+			lpPropValue[cvalues++].Value.b = zval_is_true(*entry);
 			break;
 		case PT_SYSTIME:
 			convert_to_long_ex(entry);
@@ -1089,8 +1087,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 				lpProp->Value.flt = (float)valueEntry[0]->value.dval;
 				break;
 			case PT_BOOLEAN:
-				convert_to_boolean_ex(valueEntry);
-				lpProp->Value.b = (unsigned short)valueEntry[0]->value.lval;
+				lpProp->Value.b = zval_is_true(*valueEntry);
 				break;
 			case PT_SYSTIME:
 				convert_to_long_ex(valueEntry);
@@ -2004,14 +2001,11 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			convert_to_string_ex(entry);
 			lpSOPT->alternate_boundary = Z_STRVAL_PP(entry);
 		} else if (strcmp(keyIndex, "no_recipients_workaround") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->no_recipients_workaround = Z_BVAL_PP(entry);
+			lpSOPT->no_recipients_workaround = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "headers_only") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->headers_only = Z_BVAL_PP(entry);
+			lpSOPT->headers_only = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "add_received_date") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->add_received_date = Z_BVAL_PP(entry);
+			lpSOPT->add_received_date = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "use_tnef") == 0) {
 			convert_to_long_ex(entry);
 			lpSOPT->use_tnef = Z_LVAL_PP(entry);
@@ -2019,11 +2013,9 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			convert_to_string_ex(entry);
 			lpSOPT->charset_upgrade = Z_STRVAL_PP(entry);
 		} else if (strcmp(keyIndex, "allow_send_to_everyone") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->allow_send_to_everyone = Z_BVAL_PP(entry);
+			lpSOPT->allow_send_to_everyone = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "ignore_missing_attachments") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->ignore_missing_attachments = Z_BVAL_PP(entry);
+			lpSOPT->ignore_missing_attachments = zval_is_true(*entry);
 		} else {
 			// msg_in_msg and enable_dsn not allowed, others unknown
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed sending option %s", keyIndex);
@@ -2065,23 +2057,18 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 		}
 
 		if (strcmp(keyIndex, "use_received_date") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->use_received_date = Z_BVAL_PP(entry);
+			lpDOPT->use_received_date = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "mark_as_read") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->mark_as_read = Z_BVAL_PP(entry);
+			lpDOPT->mark_as_read = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "add_imap_data") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->add_imap_data = Z_BVAL_PP(entry);
+			lpDOPT->add_imap_data = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "parse_smime_signed") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->parse_smime_signed = Z_BVAL_PP(entry);
+			lpDOPT->parse_smime_signed = zval_is_true(*entry);
 		} else if (strcmp(keyIndex, "default_charset") == 0) {
 			convert_to_string_ex(entry);
 			lpDOPT->ascii_upgrade = Z_STRVAL_PP(entry);
 		} else if (strcmp(keyIndex, "header_strict_rfc") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->header_strict_rfc = Z_BVAL_PP(entry);
+			lpDOPT->header_strict_rfc = zval_is_true(*entry);
 		} else {
 			// user_entryid not supported, others unknown
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed delivery option %s", keyIndex);

--- a/php-ext/typeconversion.cpp
+++ b/php-ext/typeconversion.cpp
@@ -68,10 +68,9 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 {
 	// local
 	HashTable		*target_hash = NULL;
-	int				count;
 	zval			**ppentry = NULL;
 	zval			*pentry = NULL;
-	int				i, n = 0;
+	unsigned int n = 0;
 
 	MAPI_G(hr) = hrSuccess;
 
@@ -81,8 +80,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 		MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		return MAPI_G(hr);
 	}
-	
-	count = zend_hash_num_elements(Z_ARRVAL_P(entryid_array));
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(entryid_array));
 	if (count == 0) {
         lpBinaryArray->lpbin = NULL;
         lpBinaryArray->cValues = 0;
@@ -95,7 +93,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
@@ -166,7 +164,6 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 {
 	// local
 	LPSSortOrderSet lpSortOrderSet = NULL;
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval			**entry = NULL;
 
@@ -177,10 +174,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoSortOrderSet");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-
-	// get the number of items in the array
-	count = zend_hash_num_elements(Z_ARRVAL_P(sortorder_array));
-
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(sortorder_array));
 	MAPI_G(hr) = MAPI_ALLOC(CbNewSSortOrderSet(count), lpBase, (void **) &lpSortOrderSet);
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
@@ -191,7 +185,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		//todo: check on FAILURE
 		char *key = NULL;
 		ulong ind = 0;
@@ -221,9 +215,6 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 {
 	// return value
 	LPSPropTagArray lpPropTagArray = NULL;
-
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval ** entry = NULL;
 
@@ -234,11 +225,7 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoPropTagArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-
-	// get the number of items in the array
-	count = zend_hash_num_elements(target_hash);
-
-	// allocate memory to use
+	auto count = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPI_ALLOC(CbNewSPropTagArray(count), lpBase, (void **)&lpPropTagArray);
 	if (MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
@@ -246,7 +233,7 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		convert_to_long_ex(entry);
 
@@ -266,8 +253,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	// return value
 	LPSPropValue	lpPropValue	= NULL;
 	ULONG			cvalues = 0;
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	HashTable		*dataHash = NULL;
 	char			*keyIndex;
@@ -292,9 +277,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoPropValueArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-
-	// Get the number of items in the array, also the number of item to use for the LPSPropValue array
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	if (count == 0) {
 	    *lppPropValArray = NULL;
 	    *lpcValues = 0;
@@ -308,7 +291,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			MAPIFreeBuffer(lpPropValue);
 	});
 
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &thpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &thpos);
 
@@ -685,7 +668,6 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 {
 	HashTable		*target_hash = NULL;
 	ULONG			countProperties = 0;		// number of properties
-	ULONG			count = 0;					// number of elements in the array
 	ULONG			countRecipients = 0;		// number of actual recipients
 	LPADRLIST		lpAdrList = NULL;
 	zval			**entry = NULL;
@@ -709,7 +691,7 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	// We allow allocing a 0 count addresslist, since we need this the OP_DELEGATE rule
 
 	MAPI_G(hr) = MAPI_ALLOC(CbNewADRLIST(count), lpBase, (void **)&lpAdrList);
@@ -751,7 +733,6 @@ exit:
 HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TSRMLS_DC) {
 	HashTable		*target_hash = NULL;
 	ULONG			countProperties = 0;		// number of properties
-	ULONG			count = 0;					// number of elements in the array
 	ULONG			countRows = 0;		// number of actual recipients
 	rowlist_ptr lpRowList;
 	zval			**entry = NULL;
@@ -770,10 +751,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoRowList");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	
-	count = zend_hash_num_elements(target_hash);
-
-	// allocate memory to store the array of pointers
+	auto count = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count), &~lpRowList);
 	if (MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
@@ -899,8 +877,6 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 	zval **typeEntry  = NULL;
 	zval **valueEntry = NULL;
 	ULONG cValues = 0;
-	int count;
-	int i;
 
 	if (!phpVal || lpRes == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "critical error");
@@ -926,7 +902,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "critical error, wrong array");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	count = zend_hash_num_elements(dataHash);
+	auto count = zend_hash_num_elements(dataHash);
 	zend_hash_internal_pointer_reset_ex(dataHash, &dhpos);
 
 	switch(lpRes->rt) {
@@ -939,7 +915,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(SRestriction) * count, lpBase, (void **) &lpRes->res.resAnd.lpRes);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
-		for (i = 0; i < count; ++i) {
+		for (unsigned int i = 0; i < count; ++i) {
 			zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, &lpRes->res.resAnd.lpRes[i] TSRMLS_CC);
 			
@@ -955,7 +931,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 
-		for (i = 0; i < count; ++i) {
+		for (unsigned int i = 0; i < count; ++i) {
 			zend_hash_get_current_data_ex(dataHash, reinterpret_cast<void **>(&valueEntry), &dhpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry[0], lpBase, &lpRes->res.resOr.lpRes[i] TSRMLS_CC);
 
@@ -1835,11 +1811,10 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 {
 	LPREADSTATE 	lpReadStates = NULL;
 	HashTable		*target_hash = NULL;
-	int				count;
 	zval			**ppentry = NULL;
 	zval			*pentry = NULL;
 	zval			**valueEntry = NULL;
-	int				n = 0, i = 0;
+	unsigned int n = 0;
 
 	MAPI_G(hr) = hrSuccess;
 
@@ -1848,16 +1823,14 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoReadStateArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	
-	count = zend_hash_num_elements(Z_ARRVAL_P(zvalReadStates));
-
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(zvalReadStates));
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(READSTATE) * count, lpBase, (void **) &lpReadStates);
 	if(MAPI_G(hr) != hrSuccess) 
 		return MAPI_G(hr);
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
@@ -1900,9 +1873,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 {
 	HashTable *target_hash = NULL;
 	LPGUID lpGUIDs = NULL;
-	int	count = 0;
-	int n = 0;
-	int i = 0;
+	unsigned int n = 0;
 	zval			**ppentry = NULL;
 	zval			*pentry = NULL;
 
@@ -1913,8 +1884,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoGUIDArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	
-	count = zend_hash_num_elements(Z_ARRVAL_P(phpVal));
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(phpVal));
 	if (count == 0) {
 		*lppGUIDs = NULL;
 		*lpcValues = 0;
@@ -1926,7 +1896,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		return MAPI_G(hr);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&ppentry), &hpos);
 		pentry = *ppentry;
 
@@ -2012,8 +1982,6 @@ HRESULT NotificationstoPHPArray(ULONG cNotifs, const NOTIFICATION *lpNotifs,
 HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 {
 	HRESULT hr = hrSuccess;
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval			**entry = NULL;
 	char			*keyIndex;
@@ -2032,10 +2000,10 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 		return hr;
 	}
 
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
 
@@ -2076,8 +2044,6 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 {
 	HRESULT hr = hrSuccess;
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval			**entry = NULL;
 	char			*keyIndex;
@@ -2096,10 +2062,10 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 		return hr;
 	}
 
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		zend_hash_get_current_data_ex(target_hash, reinterpret_cast<void **>(&entry), &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, nullptr, &numIndex, 0, &hpos);
 

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -3021,10 +3021,7 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 
 	if(guidArray)
 		guidHash = Z_ARRVAL_P(guidArray);
-
-	// get the number of items in the array
-	hashTotal = zend_hash_num_elements(targetHash);
-
+	auto hashTotal = zend_hash_num_elements(targetHash);
 	if (guidHash && hashTotal != zend_hash_num_elements(guidHash))
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "The array with the guids is not of the same size as the array with the ids");
 
@@ -3036,11 +3033,17 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 	HashPosition thpos, ghpos;
 	zend_hash_internal_pointer_reset_ex(targetHash, &thpos);
 	if(guidHash)
+<<<<<<< HEAD
 		zend_hash_internal_pointer_reset(guidHash);
 
 	for (size_t i = 0; i < hashTotal; ++i) {
 		//	Gets the element that exist at the current pointer.
 		entry = zend_hash_get_current_data(targetHash);
+=======
+		zend_hash_internal_pointer_reset_ex(guidHash, &ghpos);
+	for (unsigned int i = 0; i < hashTotal; ++i) {
+		entry = zend_hash_get_current_data_ex(targetHash, &thpos);
+>>>>>>> d8e279a... php-ext: fix type of "count"
 		if(guidHash)
 			guidEntry = zend_hash_get_current_data_ex(guidHash, &ghpos);
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(MAPINAMEID),lppNamePropId,(void **) &lppNamePropId[i]);
@@ -3052,7 +3055,7 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 
 		if(guidHash) {
 			if (Z_TYPE_P(guidEntry) != IS_STRING || sizeof(GUID) != guidEntry->value.str->len) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "The GUID with index number %d that is passed is not of the right length, cannot convert to GUID", i);
+				php_error_docref(nullptr TSRMLS_CC, E_WARNING, "The GUID with index number %u that is passed is not of the right length, cannot convert to GUID", i);
 			} else {
 				MAPI_G(hr) = KAllocCopy(guidEntry->value.str->val, sizeof(GUID), reinterpret_cast<void **>(&lppNamePropId[i]->lpguid), lppNamePropId);
 				if (MAPI_G(hr) != hrSuccess)

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -4179,12 +4179,11 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 	memory_ptr<ECQUOTA> lpQuota;
 	HashTable		*data = NULL;
 	zval			*value = NULL;
-
-        zend_string *str_usedefault = zend_string_init("usedefault", sizeof("usedefault")-1, 0);
-        zend_string *str_isuserdefault = zend_string_init("isuserdefault", sizeof("isuserdefault")-1, 0);
-        zend_string *str_warnsize = zend_string_init("warnsize", sizeof("warnsize")-1, 0);
-        zend_string *str_softsize = zend_string_init("softsize", sizeof("softsize")-1, 0);
-        zend_string *str_hardsize = zend_string_init("hardsize", sizeof("hardsize")-1, 0);
+	zstrplus str_usedefault(zend_string_init("usedefault", sizeof("usedefault") - 1, 0));
+	zstrplus str_isuserdefault(zend_string_init("isuserdefault", sizeof("isuserdefault") - 1, 0));
+	zstrplus str_warnsize(zend_string_init("warnsize", sizeof("warnsize") - 1, 0));
+	zstrplus str_softsize(zend_string_init("softsize", sizeof("softsize") - 1, 0));
+	zstrplus str_hardsize(zend_string_init("hardsize", sizeof("hardsize") - 1, 0));
 
 	RETVAL_FALSE;
 	MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -4203,27 +4202,28 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 
 	ZVAL_DEREF(array);
 	data = HASH_OF(array);
-	if ((value = zend_hash_find(data, str_usedefault)) != NULL) {
+	value = zend_hash_find(data, str_usedefault.get());
+	if (value != nullptr) {
 		convert_to_boolean_ex(value);
 		lpQuota->bUseDefaultQuota = (Z_TYPE_P(value) == IS_TRUE);
 	}
-
-	if ((value = zend_hash_find(data, str_isuserdefault)) != NULL) {
+	value = zend_hash_find(data, str_isuserdefault.get());
+	if (value != nullptr) {
 		convert_to_boolean_ex(value);
 		lpQuota->bIsUserDefaultQuota = (Z_TYPE_P(value) == IS_TRUE);
 	}
-
-	if ((value = zend_hash_find(data, str_warnsize)) != NULL) {
+	value = zend_hash_find(data, str_warnsize.get());
+	if (value != nullptr) {
 		convert_to_long_ex(value);
 		lpQuota->llWarnSize = Z_LVAL_P(value);
 	}
-
-	if ((value = zend_hash_find(data, str_softsize)) != NULL) {
+	value = zend_hash_find(data, str_softsize.get());
+	if (value != nullptr) {
 		convert_to_long_ex(value);
 		lpQuota->llSoftSize = Z_LVAL_P(value);
 	}
-
-	if ((value = zend_hash_find(data, str_hardsize)) != NULL) {
+	value = zend_hash_find(data, str_hardsize.get());
+	if (value != nullptr) {
 		convert_to_long_ex(value);
 		lpQuota->llHardSize = Z_LVAL_P(value);
 	}
@@ -4235,11 +4235,6 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 	RETVAL_TRUE;
 
 exit:
-        zend_string_release(str_usedefault);
-        zend_string_release(str_isuserdefault);
-        zend_string_release(str_warnsize);
-        zend_string_release(str_softsize);
-        zend_string_release(str_hardsize);
 	LOG_END();
 	THROW_ON_ERROR();
 }
@@ -5383,11 +5378,10 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 	ULONG j;
 	zval *entry = NULL, *value = NULL;
 	HashTable *data = NULL;
-
-	zend_string *str_userid = zend_string_init("userid", sizeof("userid")-1, 0);
-	zend_string *str_type = zend_string_init("type", sizeof("type")-1, 0);
-	zend_string *str_rights = zend_string_init("rights", sizeof("rights")-1, 0);
-	zend_string *str_state = zend_string_init("state", sizeof("state")-1, 0);
+	zstrplus str_userid(zend_string_init("userid", sizeof("userid") - 1, 0));
+	zstrplus str_type(zend_string_init("type", sizeof("type") - 1, 0));
+	zstrplus str_rights(zend_string_init("rights", sizeof("rights") - 1, 0));
+	zstrplus str_state(zend_string_init("state", sizeof("state") - 1, 0));
 
 	RETVAL_FALSE;
 	MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -5444,23 +5438,27 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 		// null pointer returned if perms was not array(array()).
 		ZVAL_DEREF(entry);
 		data = HASH_OF(entry);
-		if ((value = zend_hash_find(data, str_userid)) == nullptr)
+		value = zend_hash_find(data, str_userid.get());
+		if (value == nullptr)
 			continue;
 		convert_to_string_ex(value);
 		lpECPerms[j].sUserId.cb = Z_STRLEN_P(value);
 		lpECPerms[j].sUserId.lpb = (unsigned char*)Z_STRVAL_P(value);
 
-		if ((value = zend_hash_find(data, str_type)) == nullptr)
+		value = zend_hash_find(data, str_type.get());
+		if (value == nullptr)
 			continue;
 		convert_to_long_ex(value);
 		lpECPerms[j].ulType = Z_LVAL_P(value);
 
-		if ((value = zend_hash_find(data, str_rights)) == nullptr)
+		value = zend_hash_find(data, str_rights.get());
+		if (value == nullptr)
 			continue;
 		convert_to_long_ex(value);
 		lpECPerms[j].ulRights = Z_LVAL_P(value);
 
-		if ((value = zend_hash_find(data, str_state)) != NULL) {
+		value = zend_hash_find(data, str_state.get());
+		if (value != nullptr) {
 		    convert_to_long_ex(value);
 			lpECPerms[j].ulState = Z_LVAL_P(value);
 		} else {
@@ -5984,10 +5982,9 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 	zval*				entry = NULL;
 	zval*				value = NULL;
 	HashTable*			data = NULL;
-
-	zend_string *str_start = zend_string_init("start", sizeof("start")-1, 0);
-	zend_string *str_end = zend_string_init("end", sizeof("end")-1, 0);
-	zend_string *str_status = zend_string_init("status", sizeof("status")-1, 0);
+	zstrplus str_start(zend_string_init("start", sizeof("start") - 1, 0));
+	zstrplus str_end(zend_string_init("end", sizeof("end") - 1, 0));
+	zstrplus str_status(zend_string_init("status", sizeof("status") - 1, 0));
 
 	RETVAL_FALSE;
 	MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -6012,19 +6009,19 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 	ZEND_HASH_FOREACH_VAL(target_hash, entry) {
 		ZVAL_DEREF(entry);
 		data = HASH_OF(entry);
-		value = zend_hash_find(data, str_start);
+		value = zend_hash_find(data, str_start.get());
 		if (value == nullptr) {
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
 		lpBlocks[i].m_tmStart = UnixTimeToRTime(Z_LVAL_P(value));
-		value = zend_hash_find(data, str_end);
+		value = zend_hash_find(data, str_end.get());
 		if (value == nullptr) {
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
 		lpBlocks[i].m_tmEnd = UnixTimeToRTime(Z_LVAL_P(value));
-		value = zend_hash_find(data, str_status);
+		value = zend_hash_find(data, str_status.get());
 		if (value == nullptr) {
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
@@ -6038,9 +6035,6 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 	RETVAL_TRUE;
 
 exit:
-	zend_string_release(str_start);
-	zend_string_release(str_end);
-	zend_string_release(str_status);
 	LOG_END();
 	THROW_ON_ERROR();
 }

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -3041,7 +3041,8 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 		entry = zend_hash_get_current_data(targetHash);
 =======
 		zend_hash_internal_pointer_reset_ex(guidHash, &ghpos);
-	for (unsigned int i = 0; i < hashTotal; ++i) {
+	for (unsigned int i = 0; i < hashTotal; ++i, zend_hash_move_forward_ex(targetHash, &thpos),
+	     (guidHash ? zend_hash_move_forward_ex(guidHash, &ghpos) : 0)) {
 		entry = zend_hash_get_current_data_ex(targetHash, &thpos);
 >>>>>>> d8e279a... php-ext: fix type of "count"
 		if(guidHash)
@@ -3086,9 +3087,6 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Entry is of an unknown type: %08X", Z_TYPE_P(entry));
 			break;
 		}
-		zend_hash_move_forward_ex(targetHash, &thpos);
-		if(guidHash)
-			zend_hash_move_forward_ex(guidHash, &ghpos);
 	}
 
 	MAPI_G(hr) = lpMessageStore->GetIDsFromNames(hashTotal, lppNamePropId, MAPI_CREATE, &~lpPropTagArray);

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -4211,16 +4211,19 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 		lpQuota->bIsUserDefaultQuota = zval_is_true(value);
 	value = zend_hash_find(data, str_warnsize.get());
 	if (value != nullptr) {
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpQuota->llWarnSize = Z_LVAL_P(value);
 	}
 	value = zend_hash_find(data, str_softsize.get());
 	if (value != nullptr) {
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpQuota->llSoftSize = Z_LVAL_P(value);
 	}
 	value = zend_hash_find(data, str_hardsize.get());
 	if (value != nullptr) {
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpQuota->llHardSize = Z_LVAL_P(value);
 	}
@@ -5438,6 +5441,7 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 		value = zend_hash_find(data, str_userid.get());
 		if (value == nullptr)
 			continue;
+		SEPARATE_ZVAL(value);
 		convert_to_string_ex(value);
 		lpECPerms[j].sUserId.cb = Z_STRLEN_P(value);
 		lpECPerms[j].sUserId.lpb = (unsigned char*)Z_STRVAL_P(value);
@@ -5445,17 +5449,20 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 		value = zend_hash_find(data, str_type.get());
 		if (value == nullptr)
 			continue;
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpECPerms[j].ulType = Z_LVAL_P(value);
 
 		value = zend_hash_find(data, str_rights.get());
 		if (value == nullptr)
 			continue;
+		SEPARATE_ZVAL(value);
 		convert_to_long_ex(value);
 		lpECPerms[j].ulRights = Z_LVAL_P(value);
 
 		value = zend_hash_find(data, str_state.get());
 		if (value != nullptr) {
+			SEPARATE_ZVAL(value);
 		    convert_to_long_ex(value);
 			lpECPerms[j].ulState = Z_LVAL_P(value);
 		} else {

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -4204,15 +4204,11 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 	ZVAL_DEREF(array);
 	data = HASH_OF(array);
 	value = zend_hash_find(data, str_usedefault.get());
-	if (value != nullptr) {
-		convert_to_boolean_ex(value);
-		lpQuota->bUseDefaultQuota = (Z_TYPE_P(value) == IS_TRUE);
-	}
+	if (value != nullptr)
+		lpQuota->bUseDefaultQuota = zval_is_true(value);
 	value = zend_hash_find(data, str_isuserdefault.get());
-	if (value != nullptr) {
-		convert_to_boolean_ex(value);
-		lpQuota->bIsUserDefaultQuota = (Z_TYPE_P(value) == IS_TRUE);
-	}
+	if (value != nullptr)
+		lpQuota->bIsUserDefaultQuota = zval_is_true(value);
 	value = zend_hash_find(data, str_warnsize.get());
 	if (value != nullptr) {
 		convert_to_long_ex(value);

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -4207,8 +4207,6 @@ ZEND_FUNCTION(mapi_zarafa_setquota)
 
 	ZVAL_DEREF(array);
 	data = HASH_OF(array);
-	zend_hash_internal_pointer_reset(data);
-
 	if ((value = zend_hash_find(data, str_usedefault)) != NULL) {
 		convert_to_boolean_ex(value);
 		lpQuota->bUseDefaultQuota = (Z_TYPE_P(value) == IS_TRUE);
@@ -5450,8 +5448,6 @@ ZEND_FUNCTION(mapi_zarafa_setpermissionrules)
 		// null pointer returned if perms was not array(array()).
 		ZVAL_DEREF(entry);
 		data = HASH_OF(entry);
-		zend_hash_internal_pointer_reset(data);
-
 		if ((value = zend_hash_find(data, str_userid)) == nullptr)
 			continue;
 		convert_to_string_ex(value);
@@ -6020,8 +6016,6 @@ ZEND_FUNCTION(mapi_freebusyupdate_publish)
 	ZEND_HASH_FOREACH_VAL(target_hash, entry) {
 		ZVAL_DEREF(entry);
 		data = HASH_OF(entry);
-		zend_hash_internal_pointer_reset(data);
-
 		value = zend_hash_find(data, str_start);
 		if (value == nullptr) {
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;

--- a/php7-ext/main.cpp
+++ b/php7-ext/main.cpp
@@ -3033,9 +3033,8 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 	if (MAPI_G(hr) != hrSuccess)
 		return;
 
-	// first reset the hash, so the pointer points to the first element.
-	zend_hash_internal_pointer_reset(targetHash);
-
+	HashPosition thpos, ghpos;
+	zend_hash_internal_pointer_reset_ex(targetHash, &thpos);
 	if(guidHash)
 		zend_hash_internal_pointer_reset(guidHash);
 
@@ -3043,8 +3042,7 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 		//	Gets the element that exist at the current pointer.
 		entry = zend_hash_get_current_data(targetHash);
 		if(guidHash)
-			guidEntry = zend_hash_get_current_data(guidHash);
-
+			guidEntry = zend_hash_get_current_data_ex(guidHash, &ghpos);
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(MAPINAMEID),lppNamePropId,(void **) &lppNamePropId[i]);
 		if (MAPI_G(hr) != hrSuccess)
 			return;
@@ -3085,11 +3083,9 @@ ZEND_FUNCTION(mapi_getidsfromnames)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Entry is of an unknown type: %08X", Z_TYPE_P(entry));
 			break;
 		}
-
-		// move the pointers of the hashtables forward.
-		zend_hash_move_forward(targetHash);
+		zend_hash_move_forward_ex(targetHash, &thpos);
 		if(guidHash)
-			zend_hash_move_forward(guidHash);
+			zend_hash_move_forward_ex(guidHash, &ghpos);
 	}
 
 	MAPI_G(hr) = lpMessageStore->GetIDsFromNames(hashTotal, lppNamePropId, MAPI_CREATE, &~lpPropTagArray);

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -183,15 +183,13 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 		zend_string *key = NULL;
 		zend_ulong ind = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
-
-		// when the key is a char &key is set else ind is set
-		zend_hash_get_current_key_ex(target_hash, &key, &ind, &hpos);
-
-		if (key != NULL)
+		auto xtype = zend_hash_get_current_key_ex(target_hash, &key, &ind, &hpos);
+		if (xtype == HASH_KEY_IS_STRING)
 			lpSortOrderSet->aSort[i].ulPropTag = atoi(key->val);
-		else
+		else if (xtype == HASH_KEY_IS_LONG)
 			lpSortOrderSet->aSort[i].ulPropTag = ind;
-
+		else
+			continue;
 		convert_to_long_ex(entry);
 		lpSortOrderSet->aSort[i].ulOrder = (ULONG) entry->value.lval;
 	}
@@ -248,8 +246,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	ULONG			cvalues = 0;
 	HashTable		*target_hash = NULL;
 	HashTable		*dataHash = NULL;
-	zend_string		*keyIndex;
-	zend_ulong numIndex = 0;
 	zval			*entry = NULL;
 	ULONG			countarray = 0;
 	zval			*dataEntry = NULL;
@@ -291,10 +287,15 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(SPropValue) * count, lpBase, (void**)&lpPropValue);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
+		zend_string *keyIndex = nullptr;
+		zend_ulong numIndex = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
-		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
+		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
+		    &numIndex, &hpos) != HASH_KEY_IS_LONG) {
+			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoPropValueArray: expected array to be int-keyed");
+			continue;
+		}
 
-		// assume a numeric index
 		lpPropValue[cvalues].ulPropTag = numIndex;
 		switch(PROP_TYPE(numIndex))	{
 		case PT_SHORT:
@@ -1943,8 +1944,6 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	HRESULT hr = hrSuccess;
 	HashTable		*target_hash = NULL;
 	zval			*entry = NULL;
-	zend_string		*keyIndex;
-	zend_ulong numIndex = 0;
 
 	if (!phpArray) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoSendingOptions");
@@ -1963,8 +1962,14 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
+		zend_string *keyIndex = nullptr;
+		zend_ulong numIndex = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
-		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
+		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
+		    &numIndex, &hpos) != HASH_KEY_IS_STRING) {
+			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoSendingOptions: expected array to be string-keyed");
+			continue;
+		}
 
 		if (strcmp(keyIndex->val, "alternate_boundary") == 0) {
 			convert_to_string_ex(entry);
@@ -2003,8 +2008,6 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	HRESULT hr = hrSuccess;
 	HashTable		*target_hash = NULL;
 	zval			*entry = NULL;
-	zend_string		*keyIndex;
-	zend_ulong numIndex = 0;
 
 	if (!phpArray) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoDeliveryOptions");
@@ -2023,8 +2026,14 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
+		zend_string *keyIndex = nullptr;
+		zend_ulong numIndex = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
-		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
+		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
+		    &numIndex, &hpos) != HASH_KEY_IS_STRING) {
+			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoDeliveryOptions: expected array to be string-keyed");
+			continue;
+		}
 
 		if (strcmp(keyIndex->val, "use_received_date") == 0) {
 			convert_to_boolean_ex(entry);

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -880,8 +880,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 
 exit:
 	if (MAPI_G(hr) != hrSuccess)
-		MAPIFreeBuffer(lpRowList);
-
+		FreeProws(reinterpret_cast<SRowSet *>(lpRowList));
         zend_string_release(str_properties);
         zend_string_release(str_rowflags);
 	return MAPI_G(hr);

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -801,7 +801,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	ULONG			countProperties = 0;		// number of properties
 	ULONG			count = 0;					// number of elements in the array
 	ULONG			countRows = 0;		// number of actual recipients
-	LPROWLIST		lpRowList = NULL;
+	rowlist_ptr lpRowList;
 	zval			*entry = NULL;
 	zval			*data = NULL;
 	LPSPropValue	pPropValue = NULL;
@@ -827,8 +827,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	count = zend_hash_num_elements(target_hash);
 
 	// allocate memory to store the array of pointers
-	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count),
-	             reinterpret_cast<void **>(&lpRowList));
+	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count), &~lpRowList);
 	if (MAPI_G(hr) != hrSuccess)
 		goto exit;
 	lpRowList->cEntries = 0;
@@ -876,11 +875,8 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 		}
 		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
-	*lppRowList = lpRowList;
-
+	*lppRowList = lpRowList.release();
 exit:
-	if (MAPI_G(hr) != hrSuccess)
-		FreeProws(reinterpret_cast<SRowSet *>(lpRowList));
         zend_string_release(str_properties);
         zend_string_release(str_rowflags);
 	return MAPI_G(hr);

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -304,9 +304,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			lpPropValue[cvalues++].Value.li.QuadPart = (LONGLONG)entry->value.dval;
 			break;
 		case PT_BOOLEAN:
-			convert_to_boolean_ex(entry);
-			// lval will be 1 or 0 for true or false
-			lpPropValue[cvalues++].Value.b = (Z_TYPE_P(entry) == IS_TRUE);
+			lpPropValue[cvalues++].Value.b = zval_is_true(entry);
 			break;
 		case PT_SYSTIME:
 			convert_to_long_ex(entry);
@@ -1108,8 +1106,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 				lpProp->Value.flt = (float)valueEntry->value.dval;
 				break;
 			case PT_BOOLEAN:
-				convert_to_boolean_ex(valueEntry);
-				lpProp->Value.b = (Z_TYPE_P(valueEntry) == IS_TRUE);
+				lpProp->Value.b = zval_is_true(valueEntry);
 				break;
 			case PT_SYSTIME:
 				convert_to_long_ex(valueEntry);
@@ -1957,14 +1954,11 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			convert_to_string_ex(entry);
 			lpSOPT->alternate_boundary = Z_STRVAL_P(entry);
 		} else if (strcmp(keyIndex->val, "no_recipients_workaround") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->no_recipients_workaround = (Z_TYPE_P(entry) == IS_TRUE);
+			lpSOPT->no_recipients_workaround = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "headers_only") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->headers_only = (Z_TYPE_P(entry) == IS_TRUE);
+			lpSOPT->headers_only = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "add_received_date") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->add_received_date = (Z_TYPE_P(entry) == IS_TRUE);
+			lpSOPT->add_received_date = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "use_tnef") == 0) {
 			convert_to_long_ex(entry);
 			lpSOPT->use_tnef = Z_LVAL_P(entry);
@@ -1972,11 +1966,9 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			convert_to_string_ex(entry);
 			lpSOPT->charset_upgrade = Z_STRVAL_P(entry);
 		} else if (strcmp(keyIndex->val, "allow_send_to_everyone") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->allow_send_to_everyone = (Z_TYPE_P(entry) == IS_TRUE);
+			lpSOPT->allow_send_to_everyone = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "ignore_missing_attachments") == 0) {
-			convert_to_boolean_ex(entry);
-			lpSOPT->ignore_missing_attachments = (Z_TYPE_P(entry) == IS_TRUE);
+			lpSOPT->ignore_missing_attachments = zval_is_true(entry);
 		} else {
 			// msg_in_msg and enable_dsn not allowed, others unknown
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed sending option %s", keyIndex->val);
@@ -2013,23 +2005,18 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 		}
 
 		if (strcmp(keyIndex->val, "use_received_date") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->use_received_date = (Z_TYPE_P(entry) == IS_TRUE);
+			lpDOPT->use_received_date = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "mark_as_read") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->mark_as_read = (Z_TYPE_P(entry) == IS_TRUE);
+			lpDOPT->mark_as_read = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "add_imap_data") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->add_imap_data = (Z_TYPE_P(entry) == IS_TRUE);
+			lpDOPT->add_imap_data = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "parse_smime_signed") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->parse_smime_signed = (Z_TYPE_P(entry) == IS_TRUE);
+			lpDOPT->parse_smime_signed = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "default_charset") == 0) {
 			convert_to_string_ex(entry);
 			lpDOPT->ascii_upgrade = Z_STRVAL_P(entry);
 		} else if (strcmp(keyIndex->val, "header_strict_rfc") == 0) {
-			convert_to_boolean_ex(entry);
-			lpDOPT->header_strict_rfc = (Z_TYPE_P(entry) == TRUE);
+			lpDOPT->header_strict_rfc = zval_is_true(entry);
 		} else {
 			// user_entryid not supported, others unknown
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed delivery option %s", keyIndex->val);

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -97,6 +97,8 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (pentry == nullptr)
+			continue;
 		convert_to_string_ex(pentry);
 		MAPI_G(hr) = KAllocCopy(pentry->value.str->val, pentry->value.str->len, reinterpret_cast<void **>(&lpBinaryArray->lpbin[n].lpb), lpBase);
 		if(MAPI_G(hr) != hrSuccess)
@@ -183,6 +185,8 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 		zend_string *key = NULL;
 		zend_ulong ind = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		auto xtype = zend_hash_get_current_key_ex(target_hash, &key, &ind, &hpos);
 		if (xtype == HASH_KEY_IS_STRING)
 			lpSortOrderSet->aSort[i].ulPropTag = atoi(key->val);
@@ -227,6 +231,8 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		convert_to_long_ex(entry);
 
 		lpPropTagArray->aulPropTag[i] = entry->value.lval;
@@ -290,6 +296,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 		zend_string *keyIndex = nullptr;
 		zend_ulong numIndex = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
 		    &numIndex, &hpos) != HASH_KEY_IS_LONG) {
 			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoPropValueArray: expected array to be int-keyed");
@@ -389,6 +397,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	MAPI_G(hr) = MAPIAllocateMore(sizeof(lpPropValue[cvalues].Value.mapimvmember.mapilpmember[0]) * countarray, lpBase ? lpBase : lpPropValue, (void**)&lpPropValue[cvalues].Value.mapimvmember.mapilpmember); \
 	for (j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &hpos)) { \
 		dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos); \
+		if (dataEntry == nullptr) \
+			continue; \
 		convert_to_##type##_ex(dataEntry); \
 		lpPropValue[cvalues].Value.mapimvmember.mapilpmember[j] = dataEntry->value.phpmember; \
 	}
@@ -421,6 +431,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			for (j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &hpos)) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
+				if (dataEntry == nullptr)
+					continue;
 				convert_to_long_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVft.lpft[j] = UnixTimeToFileTime(dataEntry->value.lval);
 			}
@@ -434,6 +446,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &hpos)) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
+				if (dataEntry == nullptr)
+					continue;
 				convert_to_string_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVbin.lpbin[h].cb = dataEntry->value.str->len;
 				MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVbin.lpbin[h].lpb), lpBase != nullptr ? lpBase : lpPropValue);
@@ -451,6 +465,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &hpos)) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
+				if (dataEntry == nullptr)
+					continue;
 				convert_to_string_ex(dataEntry);
 				MAPI_G(hr) = MAPIAllocateMore(dataEntry->value.str->len+1, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA[h]);
 				if (MAPI_G(hr) != hrSuccess)
@@ -467,6 +483,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &hpos)) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
+				if (dataEntry == nullptr)
+					continue;
 				convert_to_string_ex(dataEntry);
 				if (dataEntry->value.str->len != sizeof(GUID))
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "invalid value for PT_MV_CLSID property in proptag 0x%08X, position %d,%d", lpPropValue[cvalues].ulPropTag, i, j);
@@ -504,6 +522,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 
 			for (j = 0; j < countarray; ++j, zend_hash_move_forward_ex(dataHash, &hpos)) {
 				entry = zend_hash_get_current_data_ex(dataHash, &hpos);
+				if (entry == nullptr)
+					continue;
 				ZVAL_DEREF(entry);
 				actionHash = HASH_OF(entry);
 				if (!actionHash) {
@@ -729,6 +749,8 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		ZVAL_DEREF(entry);
 
 		if(Z_TYPE_P(entry) != IS_ARRAY) {
@@ -789,6 +811,8 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	//        but since this waste is probably very minimal, we could not care less about this.
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		ZVAL_DEREF(entry);
 
 		if (Z_TYPE_P(entry) != IS_ARRAY) {
@@ -917,8 +941,16 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 
 	// structure assumption: add more checks that valueEntry becomes php array pointer?
 	typeEntry = zend_hash_get_current_data_ex(resHash, &hpos); // 0=type, 1=array
+	if (typeEntry == nullptr) {
+		php_error_docref(nullptr TSRMLS_CC, E_WARNING, "Wrong array should be array(RES_, array(values))");
+		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
+	}
 	zend_hash_move_forward_ex(resHash, &hpos);
 	valueEntry = zend_hash_get_current_data_ex(resHash, &hpos);
+	if (valueEntry == nullptr) {
+		php_error_docref(nullptr TSRMLS_CC, E_WARNING, "Wrong array should be array(RES_, array(values))");
+		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
+	}
 
 	lpRes->rt = typeEntry->value.lval;		// set restriction type (RES_AND, RES_OR, ...)
 	ZVAL_DEREF(valueEntry);
@@ -942,6 +974,8 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			return MAPI_G(hr);
 		for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(dataHash, &hpos)) {
 			valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
+			if (valueEntry == nullptr)
+				continue;
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, &lpRes->res.resAnd.lpRes[i] TSRMLS_CC);
 			
 			if (MAPI_G(hr) != hrSuccess)
@@ -956,6 +990,8 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			return MAPI_G(hr);
 		for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(dataHash, &hpos)) {
 			valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
+			if (valueEntry == nullptr)
+				continue;
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, &lpRes->res.resOr.lpRes[i] TSRMLS_CC);
 
 			if (MAPI_G(hr) != hrSuccess)
@@ -968,7 +1004,8 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
-
+		if (valueEntry == nullptr)
+			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, lpRes->res.resNot.lpRes TSRMLS_CC);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
@@ -1805,6 +1842,8 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (pentry == nullptr)
+			continue;
 		valueEntry = zend_hash_find(HASH_OF(pentry), str_sourcekey.get());
 		if (valueEntry == nullptr) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "No 'sourcekey' entry for one of the entries in the readstate list");
@@ -1866,6 +1905,8 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (unsigned int i = 0; i < count; ++i, zend_hash_move_forward_ex(target_hash, &hpos)) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (pentry == nullptr)
+			continue;
 		convert_to_string_ex(pentry);
 		
 		if(pentry->value.str->len != sizeof(GUID)){
@@ -1965,6 +2006,8 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 		zend_string *keyIndex = nullptr;
 		zend_ulong numIndex = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
 		    &numIndex, &hpos) != HASH_KEY_IS_STRING) {
 			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoSendingOptions: expected array to be string-keyed");
@@ -2029,6 +2072,8 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 		zend_string *keyIndex = nullptr;
 		zend_ulong numIndex = 0;
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		if (entry == nullptr)
+			continue;
 		if (zend_hash_get_current_key_ex(target_hash, &keyIndex,
 		    &numIndex, &hpos) != HASH_KEY_IS_STRING) {
 			php_error_docref(nullptr TSRMLS_CC, E_WARNING, "PHPArraytoDeliveryOptions: expected array to be string-keyed");

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -95,17 +95,16 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 
-	// Reset php pointer
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
-		pentry = zend_hash_get_current_data(target_hash);
+		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		convert_to_string_ex(pentry);
 		MAPI_G(hr) = KAllocCopy(pentry->value.str->val, pentry->value.str->len, reinterpret_cast<void **>(&lpBinaryArray->lpbin[n].lpb), lpBase);
 		if(MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		lpBinaryArray->lpbin[n++].cb = pentry->value.str->len;
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	lpBinaryArray->cValues = n;
@@ -184,17 +183,16 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 	lpSortOrderSet->cCategories = 0;
 	lpSortOrderSet->cExpanded = 0;
 
-	// first reset the hash, so the pointer points to the first element.
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
 		//todo: check on FAILURE
 		zend_string *key = NULL;
 		zend_ulong ind = 0;
-		entry = zend_hash_get_current_data(target_hash);
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 
 		// when the key is a char &key is set else ind is set
-		zend_hash_get_current_key(target_hash, &key, &ind);
+		zend_hash_get_current_key_ex(target_hash, &key, &ind, &hpos);
 
 		if (key != NULL)
 			lpSortOrderSet->aSort[i].ulPropTag = atoi(key->val);
@@ -203,9 +201,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 
 		convert_to_long_ex(entry);
 		lpSortOrderSet->aSort[i].ulOrder = (ULONG) entry->value.lval;
-
-		// get next hash pointer
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lppSortOrderSet = lpSortOrderSet;
@@ -244,19 +240,14 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 		return MAPI_G(hr);
 	lpPropTagArray->cValues = count;
 
-	// first reset the hash, so the pointer points to the first element.
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
-		//	Gets the element that exist at the current pointer.
-		entry = zend_hash_get_current_data(target_hash);
-		
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		convert_to_long_ex(entry);
 
 		lpPropTagArray->aulPropTag[i] = entry->value.lval;
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	
 	*lppPropTagArray = lpPropTagArray;
@@ -319,14 +310,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	    *lpcValues = 0;
 	}
 
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(SPropValue) * count, lpBase, (void**)&lpPropValue);
 
 	for (int i = 0; i < count; ++i) {
-		//	Gets the element that exist at the current pointer.
-		entry = zend_hash_get_current_data(target_hash);
-		zend_hash_get_current_key(target_hash, &keyIndex, &numIndex);
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
 
 		// assume a numeric index
 		lpPropValue[cvalues].ulPropTag = numIndex;
@@ -414,7 +404,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			lpPropValue[cvalues].Value.mapimvmember.mapilpmember = NULL; \
 			break; \
 		} \
-		zend_hash_internal_pointer_reset(dataHash); \
+		zend_hash_internal_pointer_reset_ex(dataHash, &hpos); \
 	}
 
 #define COPY_MV_PROPS(type, mapimvmember, mapilpmember, phpmember) \
@@ -423,10 +413,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	lpPropValue[cvalues].Value.mapimvmember.cValues = countarray; \
 	MAPI_G(hr) = MAPIAllocateMore(sizeof(lpPropValue[cvalues].Value.mapimvmember.mapilpmember[0]) * countarray, lpBase ? lpBase : lpPropValue, (void**)&lpPropValue[cvalues].Value.mapimvmember.mapilpmember); \
 	for (j = 0; j < countarray; ++j) { \
-		dataEntry = zend_hash_get_current_data(dataHash); \
+		dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos); \
 		convert_to_##type##_ex(dataEntry); \
 		lpPropValue[cvalues].Value.mapimvmember.mapilpmember[j] = dataEntry->value.phpmember; \
-		zend_hash_move_forward(dataHash); \
+		zend_hash_move_forward_ex(dataHash, &hpos); \
 	}
 
 		case PT_MV_I2:
@@ -456,10 +446,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(FILETIME) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVft.lpft)) != hrSuccess)
 				goto exit;
 			for (j = 0; j < countarray; ++j) {
-				dataEntry = zend_hash_get_current_data(dataHash);
+				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_long_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVft.lpft[j] = UnixTimeToFileTime(dataEntry->value.lval);
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
 			++cvalues;
 			break;
@@ -470,14 +460,14 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(SBinary) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVbin.lpbin)) != hrSuccess)
 				goto exit;
 			for (h = 0, j = 0; j < countarray; ++j) {
-				dataEntry = zend_hash_get_current_data(dataHash);
+				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_string_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVbin.lpbin[h].cb = dataEntry->value.str->len;
 				MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVbin.lpbin[h].lpb), lpBase != nullptr ? lpBase : lpPropValue);
 				if (MAPI_G(hr) != hrSuccess)
 					goto exit;
 				++h;
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
 			lpPropValue[cvalues++].Value.MVbin.cValues = h;
 			break;
@@ -488,13 +478,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(char*) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA)) != hrSuccess)
 				goto exit;
 			for (h = 0, j = 0; j < countarray; ++j) {
-				dataEntry = zend_hash_get_current_data(dataHash);
+				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_string_ex(dataEntry);
 				MAPI_G(hr) = MAPIAllocateMore(dataEntry->value.str->len+1, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA[h]);
 				if (MAPI_G(hr) != hrSuccess)
 					goto exit;
 				strncpy(lpPropValue[cvalues].Value.MVszA.lppszA[h++], dataEntry->value.str->val, dataEntry->value.str->len + 1);
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
 			lpPropValue[cvalues++].Value.MVszA.cValues = h;
 			break;
@@ -505,13 +495,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(GUID) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVguid.lpguid)) != hrSuccess)
 				goto exit;
 			for (h = 0, j = 0; j < countarray; ++j) {
-				dataEntry = zend_hash_get_current_data(dataHash);
+				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_string_ex(dataEntry);
 				if (dataEntry->value.str->len != sizeof(GUID))
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "invalid value for PT_MV_CLSID property in proptag 0x%08X, position %d,%d", lpPropValue[cvalues].ulPropTag, i, j);
 				else
 					memcpy(&lpPropValue[cvalues].Value.MVguid.lpguid[h++], dataEntry->value.str->val, sizeof(GUID));
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
 			lpPropValue[cvalues++].Value.MVguid.cValues = h;
 			break;
@@ -530,7 +520,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			dataHash = HASH_OF(entry);
 			if (!dataHash)
 				break;
-			zend_hash_internal_pointer_reset(dataHash);
+			zend_hash_internal_pointer_reset_ex(dataHash, &hpos);
 			countarray = zend_hash_num_elements(dataHash); // # of actions
 			if (countarray == 0) {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_ACTIONS is empty");
@@ -548,7 +538,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			memset(lpActions->lpAction, 0, sizeof(ACTION)*lpActions->cActions);
 
 			for (j = 0; j < countarray; ++j) {
-				entry = zend_hash_get_current_data(dataHash);
+				entry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				ZVAL_DEREF(entry);
 				actionHash = HASH_OF(entry);
 				if (!actionHash) {
@@ -690,7 +680,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					// Nothing to do
 					break;
 				};
-				zend_hash_move_forward(dataHash);
+				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
 			++cvalues;
 			break;
@@ -713,9 +703,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			goto exit;
 			break;
 		}
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lpcValues = cvalues;
@@ -773,14 +761,15 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 	lpAdrList->cEntries = 0;
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 
 	// FIXME: It is possible that the memory allocated is more than actually needed. We should first
 	//		  count the number of elements needed then allocate memory and then fill the memory.
 	//        but since this waste is probably very minimal, we could not care less about this.
 
 	for (unsigned int i = 0; i < count; ++i) {
-		entry = zend_hash_get_current_data(target_hash);
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		ZVAL_DEREF(entry);
 
 		if(Z_TYPE_P(entry) != IS_ARRAY) {
@@ -796,9 +785,7 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 		lpAdrList->aEntries[countRecipients].ulReserved1 = 0;
 		lpAdrList->aEntries[countRecipients].rgPropVals = pPropValue;
 		lpAdrList->aEntries[countRecipients].cValues = countProperties;
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 		++countRecipients;
 	}
 	*lppAdrList = lpAdrList;
@@ -845,13 +832,14 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	if (MAPI_G(hr) != hrSuccess)
 		goto exit;
 	lpRowList->cEntries = 0;
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 
 	// FIXME: It is possible that the memory allocated is more than actually needed. We should first
 	//		  count the number of elements needed then allocate memory and then fill the memory.
 	//        but since this waste is probably very minimal, we could not care less about this.
 	for (unsigned int i = 0; i < count; ++i) {
-		entry = zend_hash_get_current_data(target_hash);
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		ZVAL_DEREF(entry);
 
 		if (Z_TYPE_P(entry) != IS_ARRAY) {
@@ -886,9 +874,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
-
-		// move the pointer to the next entry
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	*lppRowList = lpRowList;
 
@@ -989,12 +975,13 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Wrong array should be array(RES_, array(values))");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	zend_hash_internal_pointer_reset(resHash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(resHash, &hpos);
 
 	// structure assumption: add more checks that valueEntry becomes php array pointer?
-	typeEntry = zend_hash_get_current_data(resHash); // 0=type, 1=array
-	zend_hash_move_forward(resHash);
-	valueEntry = zend_hash_get_current_data(resHash);
+	typeEntry = zend_hash_get_current_data_ex(resHash, &hpos); // 0=type, 1=array
+	zend_hash_move_forward_ex(resHash, &hpos);
+	valueEntry = zend_hash_get_current_data_ex(resHash, &hpos);
 
 	lpRes->rt = typeEntry->value.lval;		// set restriction type (RES_AND, RES_OR, ...)
 	ZVAL_DEREF(valueEntry);
@@ -1004,8 +991,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 	count = zend_hash_num_elements(dataHash);
-
-	zend_hash_internal_pointer_reset(dataHash);
+	zend_hash_internal_pointer_reset_ex(dataHash, &hpos);
 
 	switch(lpRes->rt) {
 	/*
@@ -1018,13 +1004,12 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		for (i = 0; i < count; ++i) {
-			valueEntry = zend_hash_get_current_data(dataHash);
-
+			valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, &lpRes->res.resAnd.lpRes[i] TSRMLS_CC);
 			
 			if (MAPI_G(hr) != hrSuccess)
 				return MAPI_G(hr);
-			zend_hash_move_forward(dataHash);
+			zend_hash_move_forward_ex(dataHash, &hpos);
 		}
 		break;
 	case RES_OR:
@@ -1034,13 +1019,12 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
 		for (i = 0; i < count; ++i) {
-			valueEntry = zend_hash_get_current_data(dataHash);
-
+			valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, &lpRes->res.resOr.lpRes[i] TSRMLS_CC);
 
 			if (MAPI_G(hr) != hrSuccess)
 				return MAPI_G(hr);
-			zend_hash_move_forward(dataHash);
+			zend_hash_move_forward_ex(dataHash, &hpos);
 		}
 		break;
 	case RES_NOT:
@@ -1048,7 +1032,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(SRestriction), lpBase, (void **) &lpRes->res.resNot.lpRes);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
-		valueEntry = zend_hash_get_current_data(dataHash);
+		valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 
 		MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, lpRes->res.resNot.lpRes TSRMLS_CC);
 		if (MAPI_G(hr) != hrSuccess)
@@ -1884,12 +1868,10 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 	if(MAPI_G(hr) != hrSuccess) 
 		goto exit;
 
-	// Reset php pointer
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
-		pentry = zend_hash_get_current_data(target_hash);
-
+		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		if((valueEntry = zend_hash_find(HASH_OF(pentry), str_sourcekey)) == NULL) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "No 'sourcekey' entry for one of the entries in the readstate list");
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -1952,12 +1934,10 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(GUID) * count, lpBase, (void **) &lpGUIDs);
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
-
-	zend_hash_internal_pointer_reset(target_hash);
-
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
-		pentry = zend_hash_get_current_data(target_hash);
-
+		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		convert_to_string_ex(pentry);
 		
 		if(pentry->value.str->len != sizeof(GUID)){
@@ -1967,7 +1947,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		}
 		
 		memcpy(&lpGUIDs[n++], pentry->value.str->val, sizeof(GUID));
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 
 	*lppGUIDs = lpGUIDs;
@@ -2056,11 +2036,11 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	}
 
 	count = zend_hash_num_elements(target_hash);
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
-		// Gets the element that exist at the current pointer.
-		entry = zend_hash_get_current_data(target_hash);
-		zend_hash_get_current_key(target_hash, &keyIndex, &numIndex);
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
 
 		if (strcmp(keyIndex->val, "alternate_boundary") == 0) {
 			convert_to_string_ex(entry);
@@ -2091,7 +2071,7 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed sending option %s", keyIndex->val);
 		}
 
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	return hr;
 }
@@ -2120,11 +2100,11 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 	}
 
 	count = zend_hash_num_elements(target_hash);
-	zend_hash_internal_pointer_reset(target_hash);
+	HashPosition hpos;
+	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (int i = 0; i < count; ++i) {
-		// Gets the element that exist at the current pointer.
-		entry = zend_hash_get_current_data(target_hash);
-		zend_hash_get_current_key(target_hash, &keyIndex, &numIndex);
+		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
+		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
 
 		if (strcmp(keyIndex->val, "use_received_date") == 0) {
 			convert_to_boolean_ex(entry);
@@ -2149,7 +2129,7 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown or disallowed delivery option %s", keyIndex->val);
 		}
 
-		zend_hash_move_forward(target_hash);
+		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	return hr;
 }

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -94,6 +94,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 		return MAPI_G(hr);
 
 	ZEND_HASH_FOREACH_VAL(target_hash, pentry) {
+		SEPARATE_ZVAL(pentry);
 		convert_to_string_ex(pentry);
 		MAPI_G(hr) = KAllocCopy(pentry->value.str->val, pentry->value.str->len, reinterpret_cast<void **>(&lpBinaryArray->lpbin[n].lpb), lpBase);
 		if(MAPI_G(hr) != hrSuccess)
@@ -180,6 +181,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 			lpSortOrderSet->aSort[i].ulPropTag = atoi(key->val);
 		else
 			lpSortOrderSet->aSort[i].ulPropTag = ind;
+		SEPARATE_ZVAL(entry);
 		convert_to_long_ex(entry);
 		lpSortOrderSet->aSort[i++].ulOrder = entry->value.lval;
 	} ZEND_HASH_FOREACH_END();
@@ -215,6 +217,7 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 
 	unsigned int n = 0;
 	ZEND_HASH_FOREACH_VAL(target_hash, entry) {
+		SEPARATE_ZVAL(entry);
 		convert_to_long_ex(entry);
 		lpPropTagArray->aulPropTag[n++] = entry->value.lval;
 	} ZEND_HASH_FOREACH_END();
@@ -282,6 +285,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 		}
 
 		lpPropValue[cvalues].ulPropTag = numIndex;
+		SEPARATE_ZVAL(entry);
 		switch(PROP_TYPE(numIndex))	{
 		case PT_SHORT:
 			convert_to_long_ex(entry);
@@ -371,6 +375,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	MAPI_G(hr) = MAPIAllocateMore(sizeof(lpPropValue[cvalues].Value.mapimvmember.mapilpmember[0]) * countarray, lpBase ? lpBase : lpPropValue, (void**)&lpPropValue[cvalues].Value.mapimvmember.mapilpmember); \
 	j = 0; \
 	ZEND_HASH_FOREACH_VAL(dataHash, dataEntry) { \
+		SEPARATE_ZVAL(dataEntry); \
 		convert_to_##type##_ex(dataEntry); \
 		lpPropValue[cvalues].Value.mapimvmember.mapilpmember[j++] = dataEntry->value.phpmember; \
 	} ZEND_HASH_FOREACH_END();
@@ -403,6 +408,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			j = 0;
 			ZEND_HASH_FOREACH_VAL(dataHash, dataEntry) {
+				SEPARATE_ZVAL(dataEntry);
 				convert_to_long_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVft.lpft[j++] = UnixTimeToFileTime(dataEntry->value.lval);
 			} ZEND_HASH_FOREACH_END();
@@ -416,6 +422,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			h = 0;
 			ZEND_HASH_FOREACH_VAL(dataHash, dataEntry) {
+				SEPARATE_ZVAL(dataEntry);
 				convert_to_string_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVbin.lpbin[h].cb = dataEntry->value.str->len;
 				MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVbin.lpbin[h].lpb), lpBase != nullptr ? lpBase : lpPropValue);
@@ -433,6 +440,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			h = 0;
 			ZEND_HASH_FOREACH_VAL(dataHash, dataEntry) {
+				SEPARATE_ZVAL(dataEntry);
 				convert_to_string_ex(dataEntry);
 				MAPI_G(hr) = MAPIAllocateMore(dataEntry->value.str->len+1, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA[h]);
 				if (MAPI_G(hr) != hrSuccess)
@@ -449,6 +457,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				return MAPI_G(hr);
 			h = 0;
 			ZEND_HASH_FOREACH_VAL(dataHash, dataEntry) {
+				SEPARATE_ZVAL(dataEntry);
 				convert_to_string_ex(dataEntry);
 				if (dataEntry->value.str->len != sizeof(GUID))
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "invalid value for PT_MV_CLSID property in proptag 0x%08X, position %d,%d", lpPropValue[cvalues].ulPropTag, i, j);
@@ -497,12 +506,14 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 				}
 
+				SEPARATE_ZVAL(dataEntry);
 				convert_to_long_ex(dataEntry);
 				lpActions->lpAction[j].acttype = (ACTTYPE)Z_LVAL_P(dataEntry);
 
 				// Option field user defined flags, default 0
 				dataEntry = zend_hash_find(actionHash, str_flags.get());
 				if (dataEntry != nullptr) {
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_long_ex(dataEntry);
 					lpActions->lpAction[j].ulFlags = Z_LVAL_P(dataEntry);
 				}
@@ -510,6 +521,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				// Option field used with OP_REPLAY and OP_FORWARD, default 0
 				dataEntry = zend_hash_find(actionHash, str_flavor.get());
 				if (dataEntry != nullptr) {
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_long_ex(dataEntry);
 					lpActions->lpAction[j].ulActionFlavor = Z_LVAL_P(dataEntry);
 				}
@@ -523,6 +535,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actMoveCopy.cbStoreEntryId = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actMoveCopy.lpStoreEntryId), lpBase != nullptr ? lpBase : lpPropValue);
@@ -533,6 +546,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_COPY/OP_MOVE but no folderentryid entry");
 						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actMoveCopy.cbFldEntryId = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actMoveCopy.lpFldEntryId), lpBase != nullptr ? lpBase : lpPropValue);
@@ -547,6 +561,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_REPLY but no replyentryid entry");
 						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actReply.cbEntryId = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actReply.lpEntryId), lpBase != nullptr ? lpBase : lpPropValue);
@@ -556,6 +571,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					// optional field
 					dataEntry = zend_hash_find(actionHash, str_replyguid.get());
 					if (dataEntry != nullptr) {
+						SEPARATE_ZVAL(dataEntry);
 						convert_to_string_ex(dataEntry);
 						if (dataEntry->value.str->len != sizeof(GUID)) {
 							php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_REPLY replyguid not sizeof(GUID)");
@@ -572,6 +588,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_DEFER_ACTION but no dam entry");
 						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actDeferAction.cbData = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actDeferAction.pbData), lpBase != nullptr ? lpBase : lpPropValue);
@@ -585,6 +602,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_BOUNCE but no code entry");
 						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
+					SEPARATE_ZVAL(dataEntry);
 					convert_to_long_ex(dataEntry);
 					lpActions->lpAction[j].scBounceCode = Z_LVAL_P(dataEntry);
 					break;
@@ -639,6 +657,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			lpPropValue[cvalues++].Value.lpszA = (char *)lpRestriction;
 			break;
 		case PT_ERROR:
+			SEPARATE_ZVAL(entry);
 			convert_to_long_ex(entry);
 			lpPropValue[cvalues].Value.err = entry->value.lval;
 			break;
@@ -1013,6 +1032,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_PROPERTY, Missing field ULPROPTAG");
 				return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			}
+			SEPARATE_ZVAL(valueEntry);
 			convert_to_long_ex(valueEntry);
 			lpRes->res.resProperty.ulPropTag = valueEntry->value.lval;
 
@@ -1021,6 +1041,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_PROPERTY, Missing field RELOP");
 				return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			}
+			SEPARATE_ZVAL(valueEntry);
 			convert_to_long_ex(valueEntry);
 			lpRes->res.resProperty.relop = valueEntry->value.lval;
 		} else {
@@ -1029,7 +1050,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_CONTENT, Missing field ULPROPTAG");
 				return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			}
-			
+			SEPARATE_ZVAL(valueEntry);
 			convert_to_long_ex(valueEntry);
 			lpRes->res.resContent.ulPropTag = valueEntry->value.lval;
 
@@ -1044,6 +1065,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_CONTENT, Missing field FUZZYLEVEL");
 					return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 				}
+				SEPARATE_ZVAL(valueEntry);
 				convert_to_long_ex(valueEntry);
 				lpRes->res.resContent.ulFuzzyLevel = valueEntry->value.lval;
 				break;
@@ -1075,6 +1097,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			else
 				lpProp->ulPropTag = lpRes->res.resContent.ulPropTag;
 
+			SEPARATE_ZVAL(valueEntry);
 			switch (PROP_TYPE(lpProp->ulPropTag)) { // sets in either resContent or resProperty
 			case PT_STRING8:
 				convert_to_string_ex(valueEntry);
@@ -1149,6 +1172,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_COMPAREPROPS, Missing field RELOP");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resCompareProps.relop = valueEntry->value.lval;
 		// ULPROPTAG1
@@ -1156,6 +1180,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_COMPAREPROPS, Missing field ULPROPTAG1");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resCompareProps.ulPropTag1 = valueEntry->value.lval;
 		// ULPROPTAG2
@@ -1163,6 +1188,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_COMPAREPROPS, Missing field ULPROPTAG2");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resCompareProps.ulPropTag2 = valueEntry->value.lval;
 		break;
@@ -1172,6 +1198,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_BITMASK, Missing field ULTYPE");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resBitMask.relBMR = valueEntry->value.lval;
 		// ULMASK
@@ -1179,6 +1206,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_BITMASK, Missing field ULMASK");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resBitMask.ulMask = valueEntry->value.lval;
 		// ULPROPTAG
@@ -1186,6 +1214,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_BITMASK, Missing field ULPROPTAG");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resBitMask.ulPropTag = valueEntry->value.lval;
 		break;
@@ -1195,6 +1224,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_SIZE, Missing field CB");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resSize.cb = valueEntry->value.lval;
 		// RELOP
@@ -1202,6 +1232,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_SIZE, Missing field RELOP");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resSize.relop = valueEntry->value.lval;
 		// ULPROPTAG
@@ -1209,6 +1240,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_SIZE, Missing field ULPROPTAG");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resSize.ulPropTag = valueEntry->value.lval;
 		break;
@@ -1218,6 +1250,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "RES_EXIST, Missing field ULPROPTAG");
 			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpRes->res.resExist.ulPropTag = valueEntry->value.lval;
 		break;
@@ -1798,7 +1831,7 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
-		
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_string_ex(valueEntry);
 		
 		MAPI_G(hr) = KAllocCopy(valueEntry->value.str->val, valueEntry->value.str->len, reinterpret_cast<void **>(&lpReadStates[n].pbSourceKey), lpBase != nullptr ? lpBase : lpReadStates);
@@ -1811,7 +1844,7 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
 		}
-		
+		SEPARATE_ZVAL(valueEntry);
 		convert_to_long_ex(valueEntry);
 		lpReadStates[n++].ulFlags = valueEntry->value.lval;
 	}
@@ -1850,6 +1883,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
 	ZEND_HASH_FOREACH_VAL(target_hash, pentry) {
+		SEPARATE_ZVAL(pentry);
 		convert_to_string_ex(pentry);
 		
 		if(pentry->value.str->len != sizeof(GUID)){
@@ -1950,6 +1984,7 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 			continue;
 		}
 
+		SEPARATE_ZVAL(entry);
 		if (strcmp(keyIndex->val, "alternate_boundary") == 0) {
 			convert_to_string_ex(entry);
 			lpSOPT->alternate_boundary = Z_STRVAL_P(entry);
@@ -2004,6 +2039,7 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 			continue;
 		}
 
+		SEPARATE_ZVAL(entry);
 		if (strcmp(keyIndex->val, "use_received_date") == 0) {
 			lpDOPT->use_received_date = zval_is_true(entry);
 		} else if (strcmp(keyIndex->val, "mark_as_read") == 0) {

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -1957,6 +1957,9 @@ HRESULT NotificationstoPHPArray(ULONG cNotifs, const NOTIFICATION *lpNotifs,
 	return MAPI_G(hr);
 }
 
+/**
+ * Update an _existing_ (and initialized) sopt structure with the flags from phpArray.
+ */
 HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 {
 	HRESULT hr = hrSuccess;
@@ -2012,6 +2015,9 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 	return hr;
 }
 
+/**
+ * Update an _existing_ (and initialized) dopt structure with the flags from phpArray.
+ */
 HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 {
 	HRESULT hr = hrSuccess;

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -274,6 +274,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	}
 
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(SPropValue) * count, lpBase, (void**)&lpPropValue);
+	auto cleanup = make_scope_success([&]() {
+		if (MAPI_G(hr) != hrSuccess && lpBase != nullptr && lpPropValue != nullptr)
+			MAPIFreeBuffer(lpPropValue);
+	});
 	zend_string *keyIndex = nullptr;
 	zend_ulong numIndex = 0;
 	unsigned int i = 0;

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -291,15 +291,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 
 	if (!phpArray) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoPropValueArray");
-		MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-		goto exit;
+		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 
 	target_hash = HASH_OF(phpArray);
 	if (!target_hash) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoPropValueArray");
-		MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-		goto exit;
+		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 
 	// Get the number of items in the array, also the number of item to use for the LPSPropValue array
@@ -356,7 +354,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			// Allocate and copy data
 			MAPI_G(hr) = KAllocCopy(entry->value.str->val, entry->value.str->len, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.bin.lpb), lpBase != nullptr ? lpBase : lpPropValue);
 			if (MAPI_G(hr) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			lpPropValue[cvalues++].Value.bin.cb =  entry->value.str->len;
 			break;
 		case PT_STRING8:
@@ -365,7 +363,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			// Allocate and copy data
 			MAPI_G(hr) = MAPIAllocateMore(entry->value.str->len+1, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.lpszA);
 			if (MAPI_G(hr) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			strncpy(lpPropValue[cvalues++].Value.lpszA, entry->value.str->val, entry->value.str->len+1);
 			break;
 		case PT_APPTIME:
@@ -376,12 +374,11 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			convert_to_string_ex(entry);
 			if (entry->value.str->len != sizeof(GUID)) {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "GUID must be 16 bytes");
-				MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-				goto exit;
+				return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			}
 			MAPI_G(hr) = KAllocCopy(entry->value.str->val, sizeof(GUID), reinterpret_cast<void **>(&lpPropValue[cvalues].Value.lpguid), lpBase != nullptr ? lpBase : lpPropValue);
 			if (MAPI_G(hr) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			++cvalues;
 			break;
 
@@ -390,8 +387,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 		dataHash = HASH_OF(entry); \
 		if (!dataHash) { \
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "No MV dataHash"); \
-			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER; \
-			goto exit; \
+			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER; \
 		} \
 	}
 
@@ -443,7 +439,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			CHECK_EMPTY_MV_ARRAY(MVft, lpft);
 			lpPropValue[cvalues].Value.MVft.cValues = countarray;
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(FILETIME) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVft.lpft)) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			for (j = 0; j < countarray; ++j) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_long_ex(dataEntry);
@@ -457,14 +453,14 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			GET_MV_HASH();
 			CHECK_EMPTY_MV_ARRAY(MVbin, lpbin);
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(SBinary) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVbin.lpbin)) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_string_ex(dataEntry);
 				lpPropValue[cvalues].Value.MVbin.lpbin[h].cb = dataEntry->value.str->len;
 				MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpPropValue[cvalues].Value.MVbin.lpbin[h].lpb), lpBase != nullptr ? lpBase : lpPropValue);
 				if (MAPI_G(hr) != hrSuccess)
-					goto exit;
+					return MAPI_G(hr);
 				++h;
 				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
@@ -475,13 +471,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			GET_MV_HASH();
 			CHECK_EMPTY_MV_ARRAY(MVszA, lppszA);
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(char*) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA)) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_string_ex(dataEntry);
 				MAPI_G(hr) = MAPIAllocateMore(dataEntry->value.str->len+1, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVszA.lppszA[h]);
 				if (MAPI_G(hr) != hrSuccess)
-					goto exit;
+					return MAPI_G(hr);
 				strncpy(lpPropValue[cvalues].Value.MVszA.lppszA[h++], dataEntry->value.str->val, dataEntry->value.str->len + 1);
 				zend_hash_move_forward_ex(dataHash, &hpos);
 			}
@@ -492,7 +488,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			GET_MV_HASH();
 			CHECK_EMPTY_MV_ARRAY(MVguid, lpguid);
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(GUID) * countarray, lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.MVguid.lpguid)) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			for (h = 0, j = 0; j < countarray; ++j) {
 				dataEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 				convert_to_string_ex(dataEntry);
@@ -507,14 +503,10 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 
 		case PT_MV_I8:
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_MV_I8 not supported");
-			MAPI_G(hr) = MAPI_E_NO_SUPPORT;
-			goto exit;
-			break;
+			return MAPI_G(hr) = MAPI_E_NO_SUPPORT;
 		case PT_MV_CURRENCY:
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_MV_CURRENCY not supported");
-			MAPI_G(hr) = MAPI_E_NO_SUPPORT;
-			goto exit;
-			break;
+			return MAPI_G(hr) = MAPI_E_NO_SUPPORT;
 		case PT_ACTIONS:
 			dataHash = HASH_OF(entry);
 			if (!dataHash)
@@ -523,17 +515,16 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			countarray = zend_hash_num_elements(dataHash); // # of actions
 			if (countarray == 0) {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_ACTIONS is empty");
-				MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-				goto exit;
+				return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			}
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(ACTIONS), lpBase ? lpBase : lpPropValue, (void **)&lpPropValue[cvalues].Value.lpszA)) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			lpActions = (ACTIONS *)lpPropValue[cvalues].Value.lpszA;
 			lpActions->ulVersion = EDK_RULES_VERSION;
 			lpActions->cActions = countarray;
 
 			if ((MAPI_G(hr) = MAPIAllocateMore(sizeof(ACTION)*lpActions->cActions, lpBase ? lpBase : lpPropValue, (void **)&lpActions->lpAction)) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 			memset(lpActions->lpAction, 0, sizeof(ACTION)*lpActions->cActions);
 
 			for (j = 0; j < countarray; ++j) {
@@ -542,14 +533,12 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				actionHash = HASH_OF(entry);
 				if (!actionHash) {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "ACTIONS structure has a wrong ACTION");
-					MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-					goto exit;
+					return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 				}
 				dataEntry = zend_hash_find(actionHash, str_action.get());
 				if (dataEntry == nullptr) {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_ACTIONS type has no action type in array");
-					MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-					goto exit;
+					return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 				}
 
 				convert_to_long_ex(dataEntry);
@@ -575,26 +564,24 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					dataEntry = zend_hash_find(actionHash, str_storeentryid.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_COPY/OP_MOVE but no storeentryid entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actMoveCopy.cbStoreEntryId = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actMoveCopy.lpStoreEntryId), lpBase != nullptr ? lpBase : lpPropValue);
 					if (MAPI_G(hr) != hrSuccess)
-						goto exit;
+						return MAPI_G(hr);
 					dataEntry = zend_hash_find(actionHash, str_folderentryid.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_COPY/OP_MOVE but no folderentryid entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actMoveCopy.cbFldEntryId = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actMoveCopy.lpFldEntryId), lpBase != nullptr ? lpBase : lpPropValue);
 					if (MAPI_G(hr) != hrSuccess)
-						goto exit;
+						return MAPI_G(hr);
 					break;
 
 				case OP_REPLY:
@@ -602,14 +589,13 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					dataEntry = zend_hash_find(actionHash, str_replyentryid.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_REPLY but no replyentryid entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actReply.cbEntryId = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actReply.lpEntryId), lpBase != nullptr ? lpBase : lpPropValue);
 					if (MAPI_G(hr) != hrSuccess)
-						goto exit;
+						return MAPI_G(hr);
 
 					// optional field
 					dataEntry = zend_hash_find(actionHash, str_replyguid.get());
@@ -617,8 +603,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						convert_to_string_ex(dataEntry);
 						if (dataEntry->value.str->len != sizeof(GUID)) {
 							php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_REPLY replyguid not sizeof(GUID)");
-							MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-							goto exit;
+							return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						} else {
 							memcpy(&lpActions->lpAction[j].actReply.guidReplyTemplate, dataEntry->value.str->val, sizeof(GUID));
 						}
@@ -629,22 +614,20 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					dataEntry = zend_hash_find(actionHash, str_dam.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_DEFER_ACTION but no dam entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					convert_to_string_ex(dataEntry);
 					lpActions->lpAction[j].actDeferAction.cbData = dataEntry->value.str->len;
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actDeferAction.pbData), lpBase != nullptr ? lpBase : lpPropValue);
 					if (MAPI_G(hr) != hrSuccess)
-						goto exit;
+						return MAPI_G(hr);
 					break;
 
 				case OP_BOUNCE:
 					dataEntry = zend_hash_find(actionHash, str_code.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_BOUNCE but no code entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					convert_to_long_ex(dataEntry);
 					lpActions->lpAction[j].scBounceCode = Z_LVAL_P(dataEntry);
@@ -654,33 +637,29 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					dataEntry = zend_hash_find(actionHash, str_adrlist.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_FORWARD/OP_DELEGATE but no adrlist entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					if (Z_TYPE_P(dataEntry) != IS_ARRAY) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_FORWARD/OP_DELEGATE adrlist entry must be an array");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					MAPI_G(hr) = PHPArraytoAdrList(dataEntry, lpBase ? lpBase : lpPropValue, &lpActions->lpAction[j].lpadrlist TSRMLS_CC);
 					if (MAPI_G(hr) != hrSuccess)
-						goto exit;
+						return MAPI_G(hr);
 					if (MAPI_G(hr) != hrSuccess){
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_DELEGATE/OP_FORWARD wrong data in adrlist entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					break;
 				case OP_TAG:
 					dataEntry = zend_hash_find(actionHash, str_proptag.get());
 					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_TAG but no proptag entry");
-						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-						goto exit;
+						return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					}
 					MAPI_G(hr) = PHPArraytoPropValueArray(dataEntry, lpBase ? lpBase : lpPropValue, &ulCountTmp, &lpPropTmp TSRMLS_CC);
 					if (MAPI_G(hr) != hrSuccess)
-						goto exit;
+						return MAPI_G(hr);
 					if (ulCountTmp > 1)
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_TAG has 'proptag' member which contains more than one property. Using the first in the array.");
 					lpActions->lpAction[j].propTag = *lpPropTmp;
@@ -699,7 +678,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			MAPI_G(hr) = PHPArraytoSRestriction(entry, lpBase ? lpBase : lpPropValue, &lpRestriction TSRMLS_CC);
 			if (MAPI_G(hr) != hrSuccess) {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArray to SRestriction failed");
-				goto exit;
+				return MAPI_G(hr);
 			}
 			lpPropValue[cvalues++].Value.lpszA = (char *)lpRestriction;
 			break;
@@ -709,9 +688,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 			break;
 		default:
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown property type %08X", PROP_TYPE(numIndex));
-			MAPI_G(hr) = MAPI_E_INVALID_TYPE;
-			goto exit;
-			break;
+			return MAPI_G(hr) = MAPI_E_INVALID_TYPE;
 		}
 		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
@@ -821,15 +798,13 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	MAPI_G(hr) = hrSuccess;
 	if (!phpArray || Z_TYPE_P(phpArray) != IS_ARRAY) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoRowList");
-		MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-		goto exit;
+		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 
 	target_hash = HASH_OF(phpArray);
 	if (!target_hash) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoRowList");
-		MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-		goto exit;
+		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 	
 	count = zend_hash_num_elements(target_hash);
@@ -837,7 +812,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	// allocate memory to store the array of pointers
 	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count), &~lpRowList);
 	if (MAPI_G(hr) != hrSuccess)
-		goto exit;
+		return MAPI_G(hr);
 	lpRowList->cEntries = 0;
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
@@ -851,19 +826,17 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 
 		if (Z_TYPE_P(entry) != IS_ARRAY) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, Row not wrapped in array");
-			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-			goto exit;
+			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
 
 		data = zend_hash_find(HASH_OF(entry), str_properties.get());
 		if (data != nullptr) {
 			MAPI_G(hr) = PHPArraytoPropValueArray(data, NULL, &countProperties, &pPropValue TSRMLS_CC);
 			if(MAPI_G(hr) != hrSuccess)
-				goto exit;
+				return MAPI_G(hr);
 		}else {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, Missing field properties");
-			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-			goto exit;
+			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
 
 		if (pPropValue) {
@@ -872,21 +845,18 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 				lpRowList->aEntries[countRows].ulRowFlags = Z_LVAL_P(data);
 			} else {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, Missing field rowflags");
-				MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-				goto exit;
+				return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			}
 			++lpRowList->cEntries;
 			lpRowList->aEntries[countRows].rgPropVals = pPropValue;
 			lpRowList->aEntries[countRows++].cValues = countProperties;
 		}else {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, critical error");
-			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
-			goto exit;
+			return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 		}
 		zend_hash_move_forward_ex(target_hash, &hpos);
 	}
 	*lppRowList = lpRowList.release();
-exit:
 	return MAPI_G(hr);
 }
 

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -71,9 +71,8 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 {
 	// local
 	HashTable		*target_hash = NULL;
-	int				count;
 	zval			*pentry = NULL;
-	int				i, n = 0;
+	unsigned int n = 0;
 
 	MAPI_G(hr) = hrSuccess;
 
@@ -82,8 +81,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoSBinaryArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	
-	count = zend_hash_num_elements(Z_ARRVAL_P(entryid_array));
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(entryid_array));
 	if (count == 0) {
         lpBinaryArray->lpbin = NULL;
         lpBinaryArray->cValues = 0;
@@ -97,7 +95,7 @@ HRESULT PHPArraytoSBinaryArray(zval * entryid_array , void *lpBase, SBinaryArray
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		convert_to_string_ex(pentry);
 		MAPI_G(hr) = KAllocCopy(pentry->value.str->val, pentry->value.str->len, reinterpret_cast<void **>(&lpBinaryArray->lpbin[n].lpb), lpBase);
@@ -160,7 +158,6 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 {
 	// local
 	LPSSortOrderSet lpSortOrderSet = NULL;
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval			*entry = NULL;
 
@@ -171,10 +168,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoSortOrderSet");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-
-	// get the number of items in the array
-	count = zend_hash_num_elements(Z_ARRVAL_P(sortorder_array));
-
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(sortorder_array));
 	MAPI_G(hr) = MAPI_ALLOC(CbNewSSortOrderSet(count), lpBase, (void **) &lpSortOrderSet);
 	if(MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
@@ -185,7 +179,7 @@ HRESULT PHPArraytoSortOrderSet(zval * sortorder_array, void *lpBase, LPSSortOrde
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		//todo: check on FAILURE
 		zend_string *key = NULL;
 		zend_ulong ind = 0;
@@ -217,9 +211,6 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 {
 	// return value
 	LPSPropTagArray lpPropTagArray = NULL;
-
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval *entry = NULL;
 
@@ -230,11 +221,7 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoPropTagArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-
-	// get the number of items in the array
-	count = zend_hash_num_elements(target_hash);
-
-	// allocate memory to use
+	auto count = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPI_ALLOC(CbNewSPropTagArray(count), lpBase, (void **)&lpPropTagArray);
 	if (MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
@@ -242,7 +229,7 @@ HRESULT PHPArraytoPropTagArray(zval * prop_value_array, void *lpBase, LPSPropTag
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		convert_to_long_ex(entry);
 
@@ -262,8 +249,6 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	// return value
 	LPSPropValue	lpPropValue	= NULL;
 	ULONG			cvalues = 0;
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	HashTable		*dataHash = NULL;
 	zend_string		*keyIndex;
@@ -299,9 +284,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoPropValueArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-
-	// Get the number of items in the array, also the number of item to use for the LPSPropValue array
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	if (count == 0) {
 	    *lppPropValArray = NULL;
 	    *lpcValues = 0;
@@ -310,8 +293,7 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	MAPI_G(hr) = MAPI_ALLOC(sizeof(SPropValue) * count, lpBase, (void**)&lpPropValue);
-
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
 
@@ -717,7 +699,6 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 {
 	HashTable		*target_hash = NULL;
 	ULONG			countProperties = 0;		// number of properties
-	ULONG			count = 0;					// number of elements in the array
 	ULONG			countRecipients = 0;		// number of actual recipients
 	LPADRLIST		lpAdrList = NULL;
 	zval			*entry = NULL;
@@ -741,7 +722,7 @@ HRESULT PHPArraytoAdrList(zval *phpArray, void *lpBase, LPADRLIST *lppAdrList TS
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
 
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	// We allow allocing a 0 count addresslist, since we need this the OP_DELEGATE rule
 
 	MAPI_G(hr) = MAPI_ALLOC(CbNewADRLIST(count), lpBase, (void **)&lpAdrList);
@@ -786,7 +767,6 @@ exit:
 HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TSRMLS_DC) {
 	HashTable		*target_hash = NULL;
 	ULONG			countProperties = 0;		// number of properties
-	ULONG			count = 0;					// number of elements in the array
 	ULONG			countRows = 0;		// number of actual recipients
 	rowlist_ptr lpRowList;
 	zval			*entry = NULL;
@@ -806,10 +786,7 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoRowList");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	
-	count = zend_hash_num_elements(target_hash);
-
-	// allocate memory to store the array of pointers
+	auto count = zend_hash_num_elements(target_hash);
 	MAPI_G(hr) = MAPIAllocateBuffer(CbNewROWLIST(count), &~lpRowList);
 	if (MAPI_G(hr) != hrSuccess)
 		return MAPI_G(hr);
@@ -934,8 +911,6 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 	zval *typeEntry  = NULL;
 	zval *valueEntry = NULL;
 	ULONG cValues = 0;
-	int count;
-	int i;
 
 	if (!phpVal || lpRes == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "critical error");
@@ -963,7 +938,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "critical error, wrong array");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	count = zend_hash_num_elements(dataHash);
+	auto count = zend_hash_num_elements(dataHash);
 	zend_hash_internal_pointer_reset_ex(dataHash, &hpos);
 
 	switch(lpRes->rt) {
@@ -976,7 +951,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(SRestriction) * count, lpBase, (void **) &lpRes->res.resAnd.lpRes);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
-		for (i = 0; i < count; ++i) {
+		for (unsigned int i = 0; i < count; ++i) {
 			valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, &lpRes->res.resAnd.lpRes[i] TSRMLS_CC);
 			
@@ -991,7 +966,7 @@ HRESULT PHPArraytoSRestriction(zval *phpVal, void* lpBase, LPSRestriction lpRes 
 		MAPI_G(hr) = MAPIAllocateMore(sizeof(SRestriction) * count, lpBase, (void **) &lpRes->res.resOr.lpRes);
 		if (MAPI_G(hr) != hrSuccess)
 			return MAPI_G(hr);
-		for (i = 0; i < count; ++i) {
+		for (unsigned int i = 0; i < count; ++i) {
 			valueEntry = zend_hash_get_current_data_ex(dataHash, &hpos);
 			MAPI_G(hr) = PHPArraytoSRestriction(valueEntry, lpBase, &lpRes->res.resOr.lpRes[i] TSRMLS_CC);
 
@@ -1818,10 +1793,9 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 {
 	LPREADSTATE 	lpReadStates = NULL;
 	HashTable		*target_hash = NULL;
-	int				count;
+	unsigned int count, n = 0;
 	zval			*pentry = NULL;
 	zval			*valueEntry = NULL;
-	int				n = 0, i = 0;
 	zstrplus str_sourcekey(zend_string_init("sourcekey", sizeof("sourcekey") - 1, 0));
 	zstrplus str_flags(zend_string_init("flags", sizeof("flags") - 1, 0));
 
@@ -1842,7 +1816,7 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		valueEntry = zend_hash_find(HASH_OF(pentry), str_sourcekey.get());
 		if (valueEntry == nullptr) {
@@ -1881,9 +1855,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 {
 	HashTable *target_hash = NULL;
 	LPGUID lpGUIDs = NULL;
-	int	count = 0;
-	int n = 0;
-	int i = 0;
+	unsigned int n = 0;
 	zval			*pentry = NULL;
 
 	MAPI_G(hr) = hrSuccess;
@@ -1893,8 +1865,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No target_hash in PHPArraytoGUIDArray");
 		return MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 	}
-	
-	count = zend_hash_num_elements(Z_ARRVAL_P(phpVal));
+	auto count = zend_hash_num_elements(Z_ARRVAL_P(phpVal));
 	if (count == 0) {
 		*lppGUIDs = NULL;
 		*lpcValues = 0;
@@ -1906,7 +1877,7 @@ HRESULT PHPArraytoGUIDArray(zval *phpVal, void *lpBase, ULONG *lpcValues, LPGUID
 		return MAPI_G(hr);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		convert_to_string_ex(pentry);
 		
@@ -1985,8 +1956,6 @@ HRESULT NotificationstoPHPArray(ULONG cNotifs, const NOTIFICATION *lpNotifs,
 HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 {
 	HRESULT hr = hrSuccess;
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval			*entry = NULL;
 	zend_string		*keyIndex;
@@ -2005,10 +1974,10 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 		return hr;
 	}
 
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
 
@@ -2049,8 +2018,6 @@ HRESULT PHPArraytoSendingOptions(zval *phpArray, sending_options *lpSOPT)
 HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 {
 	HRESULT hr = hrSuccess;
-	// local
-	int				count;
 	HashTable		*target_hash = NULL;
 	zval			*entry = NULL;
 	zend_string		*keyIndex;
@@ -2069,10 +2036,10 @@ HRESULT PHPArraytoDeliveryOptions(zval *phpArray, delivery_options *lpDOPT)
 		return hr;
 	}
 
-	count = zend_hash_num_elements(target_hash);
+	auto count = zend_hash_num_elements(target_hash);
 	HashPosition hpos;
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
-	for (int i = 0; i < count; ++i) {
+	for (unsigned int i = 0; i < count; ++i) {
 		entry = zend_hash_get_current_data_ex(target_hash, &hpos);
 		zend_hash_get_current_key_ex(target_hash, &keyIndex, &numIndex, &hpos);
 

--- a/php7-ext/typeconversion.cpp
+++ b/php7-ext/typeconversion.cpp
@@ -277,18 +277,17 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 	LPSRestriction	lpRestriction = NULL;
 	ULONG			ulCountTmp = 0; // temp value
 	LPSPropValue	lpPropTmp = NULL;
-
-        zend_string *str_action = zend_string_init("action", sizeof("action")-1, 0);
-        zend_string *str_flags = zend_string_init("flags", sizeof("flags")-1, 0);
-        zend_string *str_flavor = zend_string_init("flavor", sizeof("flavor")-1, 0);
-        zend_string *str_storeentryid = zend_string_init("storeentryid", sizeof("storeentryid")-1, 0);
-        zend_string *str_folderentryid = zend_string_init("folderentryid", sizeof("folderentryid")-1, 0);
-        zend_string *str_replyentryid = zend_string_init("replyentryid", sizeof("replyentryid")-1, 0);
-        zend_string *str_replyguid = zend_string_init("replyguid", sizeof("replyguid")-1, 0);
-        zend_string *str_dam = zend_string_init("dam", sizeof("dam")-1, 0);
-        zend_string *str_code = zend_string_init("code", sizeof("code")-1, 0);
-        zend_string *str_adrlist = zend_string_init("adrlist", sizeof("adrlist")-1, 0);
-        zend_string *str_proptag = zend_string_init("proptag", sizeof("proptag")-1, 0);
+	zstrplus str_action(zend_string_init("action", sizeof("action") - 1, 0));
+	zstrplus str_flags(zend_string_init("flags", sizeof("flags") - 1, 0));
+	zstrplus str_flavor(zend_string_init("flavor", sizeof("flavor") - 1, 0));
+	zstrplus str_storeentryid(zend_string_init("storeentryid", sizeof("storeentryid") - 1, 0));
+	zstrplus str_folderentryid(zend_string_init("folderentryid", sizeof("folderentryid") - 1, 0));
+	zstrplus str_replyentryid(zend_string_init("replyentryid", sizeof("replyentryid") - 1, 0));
+	zstrplus str_replyguid(zend_string_init("replyguid", sizeof("replyguid") - 1, 0));
+	zstrplus str_dam(zend_string_init("dam", sizeof("dam") - 1, 0));
+	zstrplus str_code(zend_string_init("code", sizeof("code") - 1, 0));
+	zstrplus str_adrlist(zend_string_init("adrlist", sizeof("adrlist") - 1, 0));
+	zstrplus str_proptag(zend_string_init("proptag", sizeof("proptag") - 1, 0));
 
 	if (!phpArray) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoPropValueArray");
@@ -546,7 +545,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					goto exit;
 				}
-				if ((dataEntry = zend_hash_find(actionHash, str_action)) == NULL) {
+				dataEntry = zend_hash_find(actionHash, str_action.get());
+				if (dataEntry == nullptr) {
 					php_error_docref(NULL TSRMLS_CC, E_WARNING, "PT_ACTIONS type has no action type in array");
 					MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 					goto exit;
@@ -556,13 +556,15 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				lpActions->lpAction[j].acttype = (ACTTYPE)Z_LVAL_P(dataEntry);
 
 				// Option field user defined flags, default 0
-				if ((dataEntry = zend_hash_find(actionHash, str_flags)) != NULL) {
+				dataEntry = zend_hash_find(actionHash, str_flags.get());
+				if (dataEntry != nullptr) {
 					convert_to_long_ex(dataEntry);
 					lpActions->lpAction[j].ulFlags = Z_LVAL_P(dataEntry);
 				}
 
 				// Option field used with OP_REPLAY and OP_FORWARD, default 0
-				if ((dataEntry = zend_hash_find(actionHash, str_flavor)) != NULL) {
+				dataEntry = zend_hash_find(actionHash, str_flavor.get());
+				if (dataEntry != nullptr) {
 					convert_to_long_ex(dataEntry);
 					lpActions->lpAction[j].ulActionFlavor = Z_LVAL_P(dataEntry);
 				}
@@ -570,7 +572,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 				switch (lpActions->lpAction[j].acttype) {
 				case OP_MOVE:
 				case OP_COPY:
-					if ((dataEntry = zend_hash_find(actionHash, str_storeentryid)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_storeentryid.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_COPY/OP_MOVE but no storeentryid entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -581,7 +584,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					MAPI_G(hr) = KAllocCopy(dataEntry->value.str->val, dataEntry->value.str->len, reinterpret_cast<void **>(&lpActions->lpAction[j].actMoveCopy.lpStoreEntryId), lpBase != nullptr ? lpBase : lpPropValue);
 					if (MAPI_G(hr) != hrSuccess)
 						goto exit;
-					if ((dataEntry = zend_hash_find(actionHash, str_folderentryid)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_folderentryid.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_COPY/OP_MOVE but no folderentryid entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -595,7 +599,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 
 				case OP_REPLY:
 				case OP_OOF_REPLY:
-					if ((dataEntry = zend_hash_find(actionHash, str_replyentryid)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_replyentryid.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_REPLY but no replyentryid entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -607,7 +612,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 						goto exit;
 
 					// optional field
-					if ((dataEntry = zend_hash_find(actionHash, str_replyguid)) != NULL) {
+					dataEntry = zend_hash_find(actionHash, str_replyguid.get());
+					if (dataEntry != nullptr) {
 						convert_to_string_ex(dataEntry);
 						if (dataEntry->value.str->len != sizeof(GUID)) {
 							php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_REPLY replyguid not sizeof(GUID)");
@@ -620,7 +626,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					break;
 
 				case OP_DEFER_ACTION:
-					if ((dataEntry = zend_hash_find(actionHash, str_dam)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_dam.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_DEFER_ACTION but no dam entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -633,7 +640,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					break;
 
 				case OP_BOUNCE:
-					if ((dataEntry = zend_hash_find(actionHash, str_code)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_code.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_BOUNCE but no code entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -643,7 +651,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					break;
 				case OP_FORWARD:
 				case OP_DELEGATE:
-					if ((dataEntry = zend_hash_find(actionHash, str_adrlist)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_adrlist.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_FORWARD/OP_DELEGATE but no adrlist entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -663,7 +672,8 @@ HRESULT PHPArraytoPropValueArray(zval* phpArray, void *lpBase, ULONG *lpcValues,
 					}
 					break;
 				case OP_TAG:
-					if ((dataEntry = zend_hash_find(actionHash, str_proptag)) == NULL) {
+					dataEntry = zend_hash_find(actionHash, str_proptag.get());
+					if (dataEntry == nullptr) {
 						php_error_docref(NULL TSRMLS_CC, E_WARNING, "OP_TAG but no proptag entry");
 						MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 						goto exit;
@@ -805,12 +815,10 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	zval			*entry = NULL;
 	zval			*data = NULL;
 	LPSPropValue	pPropValue = NULL;
+	zstrplus str_properties(zend_string_init("properties", sizeof("properties") - 1, 0));
+	zstrplus str_rowflags(zend_string_init("rowflags", sizeof("rowflags") - 1, 0));
 
 	MAPI_G(hr) = hrSuccess;
-
-        zend_string *str_properties = zend_string_init("properties", sizeof("properties")-1, 0);
-        zend_string *str_rowflags = zend_string_init("rowflags", sizeof("rowflags")-1, 0);
-
 	if (!phpArray || Z_TYPE_P(phpArray) != IS_ARRAY) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "No phpArray in PHPArraytoRowList");
 		MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
@@ -847,7 +855,8 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 			goto exit;
 		}
 
-		if ((data = zend_hash_find(HASH_OF(entry), str_properties)) != NULL) {
+		data = zend_hash_find(HASH_OF(entry), str_properties.get());
+		if (data != nullptr) {
 			MAPI_G(hr) = PHPArraytoPropValueArray(data, NULL, &countProperties, &pPropValue TSRMLS_CC);
 			if(MAPI_G(hr) != hrSuccess)
 				goto exit;
@@ -858,7 +867,8 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 		}
 
 		if (pPropValue) {
-			if ((data = zend_hash_find(HASH_OF(entry), str_rowflags)) != NULL) {
+			data = zend_hash_find(HASH_OF(entry), str_rowflags.get());
+			if (data != nullptr) {
 				lpRowList->aEntries[countRows].ulRowFlags = Z_LVAL_P(data);
 			} else {
 				php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHPArraytoRowList, Missing field rowflags");
@@ -877,8 +887,6 @@ HRESULT PHPArraytoRowList(zval *phpArray, void *lpBase, LPROWLIST *lppRowList TS
 	}
 	*lppRowList = lpRowList.release();
 exit:
-        zend_string_release(str_properties);
-        zend_string_release(str_rowflags);
 	return MAPI_G(hr);
 }
 
@@ -1844,9 +1852,8 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 	zval			*pentry = NULL;
 	zval			*valueEntry = NULL;
 	int				n = 0, i = 0;
-
-        zend_string *str_sourcekey = zend_string_init("sourcekey", sizeof("sourcekey")-1, 0);
-        zend_string *str_flags = zend_string_init("flags", sizeof("flags")-1, 0);
+	zstrplus str_sourcekey(zend_string_init("sourcekey", sizeof("sourcekey") - 1, 0));
+	zstrplus str_flags(zend_string_init("flags", sizeof("flags") - 1, 0));
 
 	MAPI_G(hr) = hrSuccess;
 
@@ -1867,7 +1874,8 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 	zend_hash_internal_pointer_reset_ex(target_hash, &hpos);
 	for (i = 0; i < count; ++i) {
 		pentry = zend_hash_get_current_data_ex(target_hash, &hpos);
-		if((valueEntry = zend_hash_find(HASH_OF(pentry), str_sourcekey)) == NULL) {
+		valueEntry = zend_hash_find(HASH_OF(pentry), str_sourcekey.get());
+		if (valueEntry == nullptr) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "No 'sourcekey' entry for one of the entries in the readstate list");
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
@@ -1879,8 +1887,8 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 		if(MAPI_G(hr) != hrSuccess)
 			goto exit;
 		lpReadStates[n].cbSourceKey = valueEntry->value.str->len;
-		
-		if((valueEntry = zend_hash_find(HASH_OF(pentry), str_flags)) == NULL) {
+		valueEntry = zend_hash_find(HASH_OF(pentry), str_flags.get());
+		if (valueEntry == nullptr) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "No 'flags' entry for one of the entries in the readstate list");
 			MAPI_G(hr) = MAPI_E_INVALID_PARAMETER;
 			goto exit;
@@ -1896,9 +1904,6 @@ HRESULT PHPArraytoReadStateArray(zval *zvalReadStates, void *lpBase, ULONG *lpcV
 exit:
 	if (MAPI_G(hr) != hrSuccess && lpBase == NULL)
 		MAPIFreeBuffer(lpReadStates);
-
-        zend_string_release(str_sourcekey);
-        zend_string_release(str_flags);
 	return MAPI_G(hr);
 }
 

--- a/php7-ext/typeconversion.h
+++ b/php7-ext/typeconversion.h
@@ -13,13 +13,21 @@
 #include "globals.h"
 ZEND_EXTERN_MODULE_GLOBALS(mapi)
 
+#include <memory>
 #include <kopano/charset/convert.h>
 #include <inetmapi/options.h>
+
+struct zstr_delete {
+	public:
+	void operator()(zend_string *s) { zend_string_release(s); }
+};
 
 struct zvalplus : public zval {
 	zvalplus() { ZVAL_NULL(this); }
 	~zvalplus() { zval_ptr_dtor(this); }
 };
+
+typedef std::unique_ptr<zend_string, zstr_delete> zstrplus;
 
 /*
  * PHP -> MAPI

--- a/spooler/rules.cpp
+++ b/spooler/rules.cpp
@@ -503,7 +503,7 @@ static wlparam wlparam_read(ECConfig *cfg)
 {
 	wlparam par;
 	auto z = cfg->GetSetting("forward_whitelist_domains_file");
-	if (z != nullptr) {
+        if (z != nullptr && strlen(z)) {
 		par.domains = tokenize(wlparam_slurp(z), "\t\n ");
 	} else {
 		z = cfg->GetSetting("forward_whitelist_domains");
@@ -511,7 +511,7 @@ static wlparam wlparam_read(ECConfig *cfg)
 			par.domains = tokenize(z, "\t ");
 	}
 	z = cfg->GetSetting("forward_whitelist_domain_message_file");
-	if (z != nullptr) {
+	if (z != nullptr && strlen(z)) {
 		par.body = convert_to<std::wstring>(wlparam_slurp(z));
 	} else {
 		z = cfg->GetSetting("forward_whitelist_domain_message");


### PR DESCRIPTION
Commit 8875503 breaks dagent's option "forward_whitelist_domains":
Dagent always tries to read wl-options from a file as it only checks existance of corresponding config-key "forward_whitelist_domains_files", but not its (empty) contents. Thus, forward_whitelist_domains values will never apply even if no whitelist-domain-file is configured (default).