### PR TITLE
Correctly set owner- and permission for unix-sockets

### DIFF
--- a/ECtools/idx_net.cpp
+++ b/ECtools/idx_net.cpp
@@ -75,7 +75,7 @@ static int idx_listen(ECConfig *cfg, std::vector<struct pollfd> &pollers)
 	x.events = POLLIN;
 	pollers.reserve(idx_sock.size());
 	for (const auto &spec : idx_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &x.fd, S_IRUSR | S_IWUSR);
+		auto ret = ec_listen_generic(spec.c_str(), &x.fd, S_IRWUG, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0)
 			return ret;
 		pollers.push_back(x);

--- a/ECtools/statsd.cpp
+++ b/ECtools/statsd.cpp
@@ -205,7 +205,7 @@ static HRESULT sd_listen(ECConfig *cfg, struct socks &sk)
 	memset(&pfd, 0, sizeof(pfd));
 	pfd.events = POLLIN;
 	for (const auto &spec : tokenize(cfg->GetSetting("statsd_listen"), ' ', true)) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0)
 			return MAPI_E_NETWORK_ERROR;
 		sk.pollfd.push_back(pfd);

--- a/caldav/CalDAV.cpp
+++ b/caldav/CalDAV.cpp
@@ -41,6 +41,7 @@
 #include <kopano/UnixUtil.h>
 #include <unicode/uclean.h>
 #include <openssl/ssl.h>
+#include <sys/stat.h>
 
 using namespace KC;
 using namespace std::string_literals;
@@ -334,7 +335,7 @@ static HRESULT ical_listen(ECConfig *cfg)
 	memset(&pfd, 0, sizeof(pfd));
 	pfd.events = POLLIN;
 	for (const auto &spec : ical_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return MAPI_E_NETWORK_ERROR;
@@ -348,7 +349,7 @@ static HRESULT ical_listen(ECConfig *cfg)
 		g_socks.ssl.push_back(false);
 	}
 	for (const auto &spec : icals_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return MAPI_E_NETWORK_ERROR;

--- a/gateway/Gateway.cpp
+++ b/gateway/Gateway.cpp
@@ -16,6 +16,7 @@
 #include <netdb.h>
 #include <poll.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <inetmapi/inetmapi.h>
 #include <mapi.h>
 #include <mapix.h>
@@ -471,7 +472,7 @@ static HRESULT gw_listen(ECConfig *cfg)
 	memset(&pfd, 0, sizeof(pfd));
 	pfd.events = POLLIN;
 	for (const auto &spec : pop3_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return MAPI_E_NETWORK_ERROR;
@@ -486,7 +487,7 @@ static HRESULT gw_listen(ECConfig *cfg)
 		g_socks.ssl.push_back(false);
 	}
 	for (const auto &spec : pop3s_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return MAPI_E_NETWORK_ERROR;
@@ -501,7 +502,7 @@ static HRESULT gw_listen(ECConfig *cfg)
 		g_socks.ssl.push_back(true);
 	}
 	for (const auto &spec : imap_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return MAPI_E_NETWORK_ERROR;
@@ -516,7 +517,7 @@ static HRESULT gw_listen(ECConfig *cfg)
 		g_socks.ssl.push_back(false);
 	}
 	for (const auto &spec : imaps_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd);
+		auto ret = ec_listen_generic(spec.c_str(), &pfd.fd, S_IRWUG | S_IROTH | S_IWOTH, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return MAPI_E_NETWORK_ERROR;

--- a/spooler/DAgent.cpp
+++ b/spooler/DAgent.cpp
@@ -2841,7 +2841,7 @@ static int dagent_listen(ECConfig *cfg, std::vector<struct pollfd> &pollers,
 	pollers.reserve(lmtp_sock.size());
 	closefd.reserve(lmtp_sock.size());
 	for (const auto &spec : lmtp_sock) {
-		auto ret = ec_listen_generic(spec.c_str(), &x.fd, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+		auto ret = ec_listen_generic(spec.c_str(), &x.fd, S_IRWUG, cfg->GetSetting("run_as_user"), cfg->GetSetting("run_as_group"));
 		if (ret < 0) {
 			ec_log_err("Listening on %s failed: %s", spec.c_str(), strerror(-ret));
 			return ret;


### PR DESCRIPTION
https://forum.kopano.io/topic/2512/socket-permissions-issues-with-kopano-server-build-8-7-81-162

Correctly set owner- and permissions for unix-sockets of
_kopano-server, kopano-dagent, kopano-gateway, kopano-caldav, kopano-stats, kopano-indexd_.
Socket permissions got substantially broken by changes introduced with commit 5995dbf7cf8.

The chosen defaults might need further review.