### PR TITLE
Fix SSL setup for Kopano 8.7.x with OpenSSL 1.1.x+

### DIFF
--- a/common/ECChannel.cpp
+++ b/common/ECChannel.cpp
@@ -91,6 +91,13 @@ HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig)
 
 	// enable *all* server methods, not just ssl2 and ssl3, but also tls1 and tls1.1
 	auto newctx = SSL_CTX_new(SSLv23_server_method());
+
+	// Check context.
+	if (newctx == nullptr) {
+		ec_log_err("ECChannel::HrSetCtx(): failed to create new SSL context");
+		return hr;
+	}
+
 #ifndef SSL_OP_NO_RENEGOTIATION
 #	define SSL_OP_NO_RENEGOTIATION 0 /* unavailable in openSSL 1.0 */
 #endif

--- a/common/ECChannel.cpp
+++ b/common/ECChannel.cpp
@@ -48,12 +48,12 @@ std::atomic<SSL_CTX *> ECChannel::lpCTX{nullptr};
 
 HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig)
 {
+	HRESULT hr = MAPI_E_CALL_FAILED;
 	if (lpConfig == NULL) {
 		ec_log_err("ECChannel::HrSetCtx(): invalid parameters");
-		return MAPI_E_CALL_FAILED;
+		return hr;
 	}
 
-	HRESULT hr = MAPI_E_CALL_FAILED;
 	const char *szFile = nullptr, *szPath = nullptr;;
 	auto cert_file = lpConfig->GetSetting("ssl_certificate_file");
 	auto key_file = lpConfig->GetSetting("ssl_private_key_file");
@@ -68,19 +68,19 @@ HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig)
 
 	if (cert_file == nullptr || key_file == nullptr) {
 		ec_log_err("ECChannel::HrSetCtx(): no cert or key file");
-		return MAPI_E_CALL_FAILED;
+		return hr;
 	}
 	auto key_fh = fopen(key_file, "r");
 	if (key_fh == nullptr) {
 		ec_log_err("ECChannel::HrSetCtx(): cannot open key file");
-		return MAPI_E_CALL_FAILED;
+		return hr;
 	}
 	fclose(key_fh);
 
 	auto cert_fh = fopen(cert_file, "r");
 	if (cert_fh == nullptr) {
 		ec_log_err("ECChannel::HrSetCtx(): cannot open cert file");
-		return MAPI_E_CALL_FAILED;
+		return hr;
 	}
 	fclose(cert_fh);
 
@@ -180,7 +180,6 @@ HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig)
 #if !defined(OPENSSL_NO_ECDH) && defined(SSL_CTX_set1_curves_list)
 	if (ssl_curves && SSL_CTX_set1_curves_list(newctx, ssl_curves) != 1) {
 		ec_log_err("Can not set SSL curve list to \"%s\": %s", ssl_curves, ERR_error_string(ERR_get_error(), 0));
-		hr = MAPI_E_CALL_FAILED;
 		goto exit;
 	}
 

--- a/common/SSLUtil.cpp
+++ b/common/SSLUtil.cpp
@@ -65,16 +65,25 @@ void ssl_threading_cleanup() {
  */
 void SSL_library_cleanup()
 {
-#ifndef OPENSSL_NO_ENGINE
-	ENGINE_cleanup();
-#endif
-	ERR_free_strings();
-#ifdef OLD_API
-	ERR_remove_state(0);
-#endif
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+	// No cleanup required, is a current OpenSSL.
+#else // OPENSSL_VERSION_NUMBER < 0x1010000fL
+	// Clean up any possible allocations.
+	OBJ_cleanup();
+	CONF_modules_free();
 	EVP_cleanup();
+#	ifndef OPENSSL_NO_ENGINE
+	ENGINE_cleanup();
+#	endif
+#	if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(OPENSSL_NO_COMP)
+	SSL_COMP_free_compression_methods();
+#	endif
+	ERR_free_strings();
+#	ifdef OLD_API
+	ERR_remove_state(0);
+#	endif
 	CRYPTO_cleanup_all_ex_data();
-	CONF_modules_unload(0);
+#endif // OPENSSL_VERSION_NUMBER
 }
 
 void ssl_random_init()

--- a/common/include/kopano/ECChannel.h
+++ b/common/include/kopano/ECChannel.h
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <iostream>
 #include <sys/socket.h>
+#include <openssl/opensslconf.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <kopano/ECConfig.h>


### PR DESCRIPTION
This patch implements conditional new-style SSL setup for Kopano daemons using the
API that OpenSSL 1.1.x exposes, setting minimum/maximum protocol and using a
one-stop initialization function and implicit cleanup. The code tries to keep the
current configuration options for SSL intact (i.e., uses an Apache-style heuristic
to map a set of disabled/enabled protocols to a min/max-range), and does not
introduce additional SSL parameters.

In addition to the OpenSSL initialization changes, this patch also fixes problems
with the ECChannel std::atomic implementation which seems incomplete as it stands
(see commit 9f9a199a6e60d146dbc5ae444f3116650328fad1), and two small semantic
problems with the use of SSL_shutdown/SSL_clear in the initialization routine
for an SSL connection.