### PR TITLE
Fix SSL_CTX management in ECChannel.cpp

### DIFF
--- a/common/ECChannel.cpp
+++ b/common/ECChannel.cpp
@@ -378,11 +378,13 @@ ECChannel::~ECChannel() {
 }
 
 HRESULT ECChannel::HrEnableTLS(void) {
-	int rc = -1;
-	HRESULT hr = hrSuccess;
+	if (lpSSL) {
+		ec_log_err("ECChannel::HrEnableTLS(): trying to reenable TLS channel");
+		return MAPI_E_CALL_FAILED;
+	}
 
-	if (lpSSL || lpCTX == NULL) {
-		hr = MAPI_E_CALL_FAILED;
+	HRESULT hr = MAPI_E_CALL_FAILED;
+	if (lpCTX == NULL) {
 		ec_log_err("ECChannel::HrEnableTLS(): invalid parameters");
 		goto exit;
 	}
@@ -390,7 +392,6 @@ HRESULT ECChannel::HrEnableTLS(void) {
 	lpSSL = SSL_new(lpCTX);
 	if (!lpSSL) {
 		ec_log_err("ECChannel::HrEnableTLS(): SSL_new failed");
-		hr = MAPI_E_CALL_FAILED;
 		goto exit;
 	}
 
@@ -402,19 +403,21 @@ HRESULT ECChannel::HrEnableTLS(void) {
 
 	if (SSL_set_fd(lpSSL, fd) != 1) {
 		ec_log_err("ECChannel::HrEnableTLS(): SSL_set_fd failed");
-		hr = MAPI_E_CALL_FAILED;
 		goto exit;
 	}
 
 	ERR_clear_error();
+	int rc;
 	if ((rc = SSL_accept(lpSSL)) != 1) {
 		int err = SSL_get_error(lpSSL, rc);
 		ec_log_err("ECChannel::HrEnableTLS(): SSL_accept failed: %d", err);
 		if (err != SSL_ERROR_SYSCALL && err != SSL_ERROR_SSL)
 			SSL_shutdown(lpSSL);
-		hr = MAPI_E_CALL_FAILED;
 		goto exit;
 	}
+
+	hr = hrSuccess;
+
 exit:
 	if (hr != hrSuccess && lpSSL) {
 		SSL_free(lpSSL);

--- a/common/ECChannel.cpp
+++ b/common/ECChannel.cpp
@@ -46,8 +46,7 @@ openssl req -new -x509 -key privkey.pem -out cacert.pem -days 1095
 
 std::atomic<SSL_CTX *> ECChannel::lpCTX{nullptr};
 
-HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig)
-{
+HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig) {
 	HRESULT hr = MAPI_E_CALL_FAILED;
 	if (lpConfig == NULL) {
 		ec_log_err("ECChannel::HrSetCtx(): invalid parameters");
@@ -357,8 +356,7 @@ HRESULT ECChannel::HrFreeCtx() {
 }
 
 ECChannel::ECChannel(int inputfd) :
-	fd(inputfd), peer_atxt(), peer_sockaddr()
-{
+	fd(inputfd), peer_atxt(), peer_sockaddr() {
 }
 
 ECChannel::~ECChannel() {
@@ -369,8 +367,7 @@ ECChannel::~ECChannel() {
 	close(fd);
 }
 
-HRESULT ECChannel::HrEnableTLS(void)
-{
+HRESULT ECChannel::HrEnableTLS(void) {
 	int rc = -1;
 	HRESULT hr = hrSuccess;
 

--- a/common/ECChannel.cpp
+++ b/common/ECChannel.cpp
@@ -5,6 +5,8 @@
 #include <kopano/platform.h>
 #include <memory>
 #include <new>
+#include <shared_mutex>
+#include <mutex>
 #include <climits>
 #include <cstdint>
 #include <cstdlib>
@@ -44,7 +46,8 @@ Creating a self-signed test certificate:
 openssl req -new -x509 -key privkey.pem -out cacert.pem -days 1095
 */
 
-std::atomic<SSL_CTX *> ECChannel::lpCTX{nullptr};
+std::shared_mutex ECChannel::ctx_lock;
+SSL_CTX *ECChannel::lpCTX;
 
 HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig) {
 	if (lpConfig == NULL) {
@@ -71,24 +74,32 @@ HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig) {
 		goto exit;
 	}
 
+	// Initialize SSL library under context lock; normally, this should only
+	// happen on the first run of the SSL initializer and generally just once.
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-	// New style init.
-	if (lpCTX == nullptr)
-		OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
+	{
+		// New style init.
+		std::unique_lock lck(ctx_lock);
+		if (lpCTX == nullptr)
+			OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
+	}
 
 	// Default TLS context for OpenSSL >= 1.1, enables all methods.
 	ctx = SSL_CTX_new(TLS_server_method());
 #else // OPENSSL_VERSION_NUMBER < 0x1010000fL
-	// Old style init, modelled after Apache mod_ssl.
-	if (lpCTX == nullptr) {
-		ERR_load_crypto_strings();
-		SSL_load_error_strings();
-		SSL_library_init();
+	{
+		// Old style init, modelled after Apache mod_ssl.
+		std::unique_lock lck(ctx_lock);
+		if (lpCTX == nullptr) {
+			ERR_load_crypto_strings();
+			SSL_load_error_strings();
+			SSL_library_init();
 #	ifndef OPENSSL_NO_ENGINE
-		ENGINE_load_builtin_engines();
+			ENGINE_load_builtin_engines();
 #	endif // !OPENSSL_NO_ENGINE
-		OpenSSL_add_all_algorithms();
-		OPENSSL_load_builtin_modules();
+			OpenSSL_add_all_algorithms();
+			OPENSSL_load_builtin_modules();
+		}
 	}
 
 	// enable *all* server methods, not just ssl2 and ssl3, but also tls1 and tls1.1
@@ -325,9 +336,12 @@ HRESULT ECChannel::HrSetCtx(ECConfig *lpConfig) {
 		goto exit;
 	}
 
-	// Swap in generated SSL context.
-	ctx = lpCTX.exchange(ctx);
-	hr = hrSuccess;
+	// Swap in newly generated SSL context.
+	{
+		std::unique_lock lck(ctx_lock);
+		std::swap(lpCTX, ctx);
+		hr = hrSuccess;
+	}
 
 exit:
 	// Clean up remaining context; when this is an old and not a failed context, the corresponding
@@ -338,10 +352,16 @@ exit:
 }
 
 HRESULT ECChannel::HrFreeCtx() {
-	// Swap out current SSL context.
-	auto oldctx = lpCTX.exchange(nullptr);
-	if (oldctx != nullptr)
-		SSL_CTX_free(oldctx);
+	// Swap out current SSL context from global context pointer.
+	SSL_CTX *ctx = nullptr;
+	{
+		std::unique_lock lck(ctx_lock);
+		std::swap(lpCTX, ctx);
+	}
+
+	// Clean up retrieved context.
+	if (ctx != nullptr)
+		SSL_CTX_free(ctx);
 	return hrSuccess;
 }
 

--- a/common/ECChannel.cpp
+++ b/common/ECChannel.cpp
@@ -383,46 +383,52 @@ HRESULT ECChannel::HrEnableTLS(void) {
 		return MAPI_E_CALL_FAILED;
 	}
 
+	// Access context under shared lock to avoid races with HrSetCtx setting up a new context.
+	SSL *ssl = nullptr;
 	HRESULT hr = MAPI_E_CALL_FAILED;
-	if (lpCTX == NULL) {
-		ec_log_err("ECChannel::HrEnableTLS(): invalid parameters");
-		goto exit;
+	{
+		std::shared_lock lck(ctx_lock);
+		if (lpCTX == NULL) {
+			ec_log_err("ECChannel::HrEnableTLS(): trying to enable TLS channel when not set up");
+			goto exit;
+		}
+		ssl = SSL_new(lpCTX);
 	}
 
-	lpSSL = SSL_new(lpCTX);
-	if (!lpSSL) {
+	if (ssl == nullptr) {
 		ec_log_err("ECChannel::HrEnableTLS(): SSL_new failed");
 		goto exit;
 	}
 
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL
-	ec_log_info("ECChannel::HrEnableTLS(): min TLS version 0x%lx", SSL_get_min_proto_version(lpSSL));
-	ec_log_info("ECChannel::HrEnableTLS(): max TLS version 0x%lx", SSL_get_max_proto_version(lpSSL));
+	ec_log_info("ECChannel::HrEnableTLS(): min TLS version 0x%lx", SSL_get_min_proto_version(ssl));
+	ec_log_info("ECChannel::HrEnableTLS(): max TLS version 0x%lx", SSL_get_max_proto_version(ssl));
 #endif
-	ec_log_info("ECChannel::HrEnableTLS(): TLS flags 0x%lx", SSL_get_options(lpSSL));
+	ec_log_info("ECChannel::HrEnableTLS(): TLS flags 0x%lx", SSL_get_options(ssl));
 
-	if (SSL_set_fd(lpSSL, fd) != 1) {
+	if (SSL_set_fd(ssl, fd) != 1) {
 		ec_log_err("ECChannel::HrEnableTLS(): SSL_set_fd failed");
 		goto exit;
 	}
 
 	ERR_clear_error();
 	int rc;
-	if ((rc = SSL_accept(lpSSL)) != 1) {
-		int err = SSL_get_error(lpSSL, rc);
+	if ((rc = SSL_accept(ssl)) != 1) {
+		int err = SSL_get_error(ssl, rc);
 		ec_log_err("ECChannel::HrEnableTLS(): SSL_accept failed: %d", err);
 		if (err != SSL_ERROR_SYSCALL && err != SSL_ERROR_SSL)
-			SSL_shutdown(lpSSL);
+			SSL_shutdown(ssl);
 		goto exit;
 	}
 
+	// Swap in newly created SSL object for this channel.
+	std::swap(lpSSL, ssl);
 	hr = hrSuccess;
 
 exit:
-	if (hr != hrSuccess && lpSSL) {
-		SSL_free(lpSSL);
-		lpSSL = NULL;
-	}
+	// Clean up possibly remaining SSL object.
+	if (ssl != nullptr)
+		SSL_free(ssl);
 	return hr;
 }
 

--- a/common/include/kopano/ECChannel.h
+++ b/common/include/kopano/ECChannel.h
@@ -6,7 +6,7 @@
 #ifndef ECCHANNEL_H
 #define ECCHANNEL_H
 
-#include <atomic>
+#include <shared_mutex>
 #include <set>
 #include <string>
 #include <utility>
@@ -57,7 +57,8 @@ public:
 private:
 	int fd;
 	SSL *lpSSL = nullptr;
-	static std::atomic<SSL_CTX *> lpCTX;
+	static std::shared_mutex ctx_lock;
+	static SSL_CTX *lpCTX;
 	char peer_atxt[256+16];
 	struct sockaddr_storage peer_sockaddr;
 	socklen_t peer_salen = 0;


### PR DESCRIPTION
The SSL_CTX management in ECChannel.cpp is broken since commit 9f9a199. For one, the patch is incomplete (see the first patch in this patchset for a simple, but wrong completion of that patch), for another, the original patch tries to resolve a data race, which cannot be resolved with the usage of std::atomic, but rather needs locks.

This patch series implements proper SSL_CTX handling using a shared_mutex which removes any data race possibility.