### PR TITLE
KC 8.7.x: add LDAP plugin local/non-local attribute to allow user objects to fall back to contacts

### DIFF
--- a/doc/kopano-ldap.cfg.5
+++ b/doc/kopano-ldap.cfg.5
@@ -239,6 +239,17 @@ Default for OpenLDAP:
 .PP
 Default for ADS:
 \fIbinary\fR
+.SS ldap_user_local_attribute
+.PP
+This specifies an attribute to check whether the current user is local for the Kopano installation. When the resolved attribute is set for a user or the configuration option is unset, the user is considered local, when the configuration option is set and attribute is unset (has no value in the directory) for a user, the user is considered non-local.
+.PP
+In case a user is resolved as being non-local, the user is treated as being a contact, regardless of otherwise having a full Kopano object setup which would qualify for a mailbox.
+.PP
+In multi-server installations, the kopanoUserServer attribute which is a single-valued string signals the home server of the corresponding user. (Re-)using this attribute as the qualification for local/non-local (non-local being equivalent to no home-server being set up, local being equivalent to a home-server being set up) is possible for single and multi-server installations.
+.PP
+Default for OpenLDAP is empty.
+.PP
+Default for ADS is empty.
 .SS ldap_fullname_attribute
 .PP
 This value is the fullname of a user. It will be used on outgoing messages, and store names.

--- a/provider/plugins/LDAPUserPlugin.cpp
+++ b/provider/plugins/LDAPUserPlugin.cpp
@@ -362,6 +362,7 @@ LDAPUserPlugin::LDAPUserPlugin(std::mutex &pluginlock,
 		{ "ldap_user_unique_attribute","cn", CONFIGSETTING_RELOADABLE },
 		{ "ldap_user_unique_attribute_type","text", CONFIGSETTING_RELOADABLE },
 		{ "ldap_user_unique_attribute_name","objectClass", CONFIGSETTING_RELOADABLE },
+		{ "ldap_user_local_attribute","", CONFIGSETTING_RELOADABLE },
 		{ "ldap_group_search_base","", CONFIGSETTING_UNUSED },
 		{ "ldap_group_search_filter","", CONFIGSETTING_RELOADABLE },
 		{ "ldap_group_unique_attribute","cn", CONFIGSETTING_RELOADABLE },
@@ -758,6 +759,7 @@ objectid_t LDAPUserPlugin::GetObjectIdForEntry(LDAPMessage *entry)
 	const char *security_attr = m_config->GetSetting("ldap_group_security_attribute");
 	const char *security_attr_type = m_config->GetSetting("ldap_group_security_attribute_type");
 	const char *user_unique_attr = m_config->GetSetting("ldap_user_unique_attribute");
+	const char *user_local_attr = m_config->GetSetting("ldap_user_local_attribute");
 	const char *group_unique_attr = m_config->GetSetting("ldap_group_unique_attribute");
 	const char *company_unique_attr = m_config->GetSetting("ldap_company_unique_attribute");
 	const char *addresslist_unique_attr = m_config->GetSetting("ldap_addresslist_unique_attribute");
@@ -893,13 +895,14 @@ signatures_t LDAPUserPlugin::getAllObjectsByFilter(const std::string &basedn,
 	if (m_bHosted && !strCompanyDN.empty())
 		dnFilter = m_lpCache->getChildrenForDN(m_lpCache->getObjectDNCache(this, CONTAINER_COMPANY), strCompanyDN);
 
-	auto request_attrs = std::make_unique<attrArray>(15);
+	auto request_attrs = std::make_unique<attrArray>(16);
 	/* Needed for GetObjectIdForEntry() */
 	CONFIG_TO_ATTR(request_attrs, class_attr, "ldap_object_type_attribute");
 	CONFIG_TO_ATTR(request_attrs, nonactive_attr, "ldap_nonactive_attribute");
 	CONFIG_TO_ATTR(request_attrs, resource_attr, "ldap_resource_type_attribute");
 	CONFIG_TO_ATTR(request_attrs, security_attr, "ldap_group_security_attribute");
 	CONFIG_TO_ATTR(request_attrs, user_unique_attr, "ldap_user_unique_attribute");
+	CONFIG_TO_ATTR(request_attrs, user_local_attr, "ldap_user_local_attribute");
 	CONFIG_TO_ATTR(request_attrs, group_unique_attr, "ldap_group_unique_attribute");
 	CONFIG_TO_ATTR(request_attrs, company_unique_attr, "ldap_company_unique_attribute");
 	CONFIG_TO_ATTR(request_attrs, addresslist_unique_attr, "ldap_addresslist_unique_attribute");
@@ -1000,6 +1003,7 @@ string LDAPUserPlugin::getSearchFilter(objectclass_t objclass)
 	const char *companytype = m_config->GetSetting("ldap_company_type_attribute_value", "", NULL);
 	const char *addresslisttype = m_config->GetSetting("ldap_addresslist_type_attribute_value", "", NULL);
 	const char *dynamicgrouptype = m_config->GetSetting("ldap_dynamicgroup_type_attribute_value", "", NULL);
+	const char *userlocalattr = m_config->GetSetting("ldap_user_local_attribute");
 	const char *userfilter = m_config->GetSetting("ldap_user_search_filter");
 	const char *groupfilter = m_config->GetSetting("ldap_group_search_filter");
 	const char *companyfilter = m_config->GetSetting("ldap_company_search_filter");
@@ -1660,11 +1664,12 @@ LDAPUserPlugin::getObjectDetails(const std::list<objectid_t> &objectids)
 	list<postaction> lPostActions;
 	std::set<objectid_t> setObjectIds;
 	list<configsetting_t>	lExtraAttrs = m_config->GetSettingGroup(CONFIGGROUP_PROPMAP);
-	auto request_attrs = std::make_unique<attrArray>(33 + lExtraAttrs.size());
+	auto request_attrs = std::make_unique<attrArray>(34 + lExtraAttrs.size());
 
 	CONFIG_TO_ATTR(request_attrs, object_attr, "ldap_object_type_attribute");
 	CONFIG_TO_ATTR(request_attrs, user_unique_attr, "ldap_user_unique_attribute");
 	CONFIG_TO_ATTR(request_attrs, user_unique_attr_type, "ldap_user_unique_attribute_type");
+	CONFIG_TO_ATTR(request_attrs, user_local_attr, "ldap_user_local_attribute");
 	CONFIG_TO_ATTR(request_attrs, user_fullname_attr, "ldap_fullname_attribute");
 	CONFIG_TO_ATTR(request_attrs, loginname_attr, "ldap_loginname_attribute");
 	CONFIG_TO_ATTR(request_attrs, password_attr, "ldap_password_attribute");

--- a/provider/plugins/LDAPUserPlugin.cpp
+++ b/provider/plugins/LDAPUserPlugin.cpp
@@ -751,7 +751,7 @@ objectid_t LDAPUserPlugin::GetObjectIdForEntry(LDAPMessage *entry)
 {
 	list<string>	objclasses;
 	std::string nonactive_type, resource_type, security_type;
-	std::string user_unique, group_unique, company_unique;
+	std::string user_unique, user_local, group_unique, company_unique;
 	std::string addresslist_unique, dynamicgroup_unique, object_uid;
 	const char *class_attr = m_config->GetSetting("ldap_object_type_attribute");
 	const char *nonactive_attr = m_config->GetSetting("ldap_nonactive_attribute");
@@ -782,6 +782,8 @@ objectid_t LDAPUserPlugin::GetObjectIdForEntry(LDAPMessage *entry)
 			security_type = getLDAPAttributeValue(att, entry);
 		if (user_unique_attr && strcasecmp(att, user_unique_attr) == 0)
 			user_unique = getLDAPAttributeValue(att, entry);
+		if (user_local_attr && strcasecmp(att, user_local_attr) == 0)
+			user_local = getLDAPAttributeValue(att, entry);
 		if (group_unique_attr && strcasecmp(att, group_unique_attr) == 0)
 			group_unique = getLDAPAttributeValue(att, entry);
 		if (company_unique_attr && strcasecmp(att, company_unique_attr) == 0)
@@ -814,9 +816,12 @@ objectid_t LDAPUserPlugin::GetObjectIdForEntry(LDAPMessage *entry)
 	if(MatchClasses(setObjectClasses, lstLDAPObjectClasses))
 		lstMatches.emplace_back(lstLDAPObjectClasses.size(), OBJECTCLASS_USER); // Could still be active or nonactive, will resolve later
 
-	lstLDAPObjectClasses = split_classes(class_contact_type);
-	if(MatchClasses(setObjectClasses, lstLDAPObjectClasses))
-		lstMatches.emplace_back(lstLDAPObjectClasses.size(), NONACTIVE_CONTACT);
+	// Only resolve contact type through LDAP class if actually set up.
+	if (class_contact_type && *class_contact_type) {
+		lstLDAPObjectClasses = split_classes(class_contact_type);
+		if(MatchClasses(setObjectClasses, lstLDAPObjectClasses))
+			lstMatches.emplace_back(lstLDAPObjectClasses.size(), NONACTIVE_CONTACT);
+	}
 
 	lstLDAPObjectClasses = split_classes(class_group_type);
 	if(MatchClasses(setObjectClasses, lstLDAPObjectClasses))
@@ -844,15 +849,19 @@ objectid_t LDAPUserPlugin::GetObjectIdForEntry(LDAPMessage *entry)
 
 	// Subspecify some generic types now
 	if (objclass == OBJECTCLASS_USER) {
-		objclass = atoi(nonactive_type.c_str()) == 0 ? ACTIVE_USER : NONACTIVE_USER;
-		if (objclass == NONACTIVE_USER && !resource_type.empty()) {
-			/* Overwrite objectclass, a resource is allowed to overwrite the nonactive type */
-			if (strcasecmp(resource_type.c_str(), "room") == 0)
-				objclass = NONACTIVE_ROOM;
-			else if (strcasecmp(resource_type.c_str(), "equipment") == 0)
-				objclass = NONACTIVE_EQUIPMENT;
-		}
-		object_uid = user_unique;
+		if (!user_local_attr || !*user_local_attr || !user_local.empty()) {
+			objclass = atoi(nonactive_type.c_str()) == 0 ? ACTIVE_USER : NONACTIVE_USER;
+			if (objclass == NONACTIVE_USER && !resource_type.empty()) {
+				/* Overwrite objectclass, a resource is allowed to overwrite the nonactive type */
+				if (strcasecmp(resource_type.c_str(), "room") == 0)
+					objclass = NONACTIVE_ROOM;
+				else if (strcasecmp(resource_type.c_str(), "equipment") == 0)
+					objclass = NONACTIVE_EQUIPMENT;
+			}
+			object_uid = user_unique;
+		} else
+			// Use contact type when user has empty/unset local server attribute.
+			objclass = NONACTIVE_CONTACT;
 	}
 
 	if (objclass == NONACTIVE_CONTACT)
@@ -1030,18 +1039,32 @@ string LDAPUserPlugin::getSearchFilter(objectclass_t objclass)
 		if (!usertype)
 			throw runtime_error("No user type attribute value defined");
 		filter = userfilter;
-		subfilter += "(|";
+		subfilter = "(|";
+		subfilter += "(&";
 		subfilter += GetObjectClassFilter(objecttype, usertype);
+		if (objclass != OBJECTCLASS_USER && userlocalattr && *userlocalattr)
+			subfilter += "(" + string(userlocalattr) + "=*)";
+		subfilter += ")";
 		/* Generic user type should not exclude Contacts */
-		if (objclass == OBJECTCLASS_USER && contacttype)
+		if (objclass == OBJECTCLASS_USER && contacttype && *contacttype)
 			subfilter += GetObjectClassFilter(objecttype, contacttype);
 		subfilter += ")";
 		break;
 	case NONACTIVE_CONTACT:
-		if (!contacttype)
-			throw runtime_error("No contact type attribute value defined");
 		filter = userfilter;
-		subfilter = GetObjectClassFilter(objecttype, contacttype);
+		subfilter = "(|";
+		if (userlocalattr && *userlocalattr) {
+			if (!usertype)
+				throw runtime_error("No user type attribute value defined");
+			subfilter += "(&";
+			subfilter += GetObjectClassFilter(objecttype, usertype);
+			subfilter += "(!(" + string(userlocalattr) + "=*))";
+			subfilter += ")";
+		} else if (!contacttype || !*contacttype)
+			throw runtime_error("No contact type attribute value defined");
+		if (contacttype && *contacttype)
+			subfilter += GetObjectClassFilter(objecttype, contacttype);
+		subfilter += ")";
 		break;
 	case OBJECTCLASS_DISTLIST:
 	case DISTLIST_GROUP:

--- a/provider/plugins/LDAPUserPlugin.cpp
+++ b/provider/plugins/LDAPUserPlugin.cpp
@@ -1011,13 +1011,12 @@ string LDAPUserPlugin::getSearchFilter(objectclass_t objclass)
 
 	switch (objclass) {
 	case OBJECTCLASS_UNKNOWN:
-		/* No objectclass is given, merge all filters together */
-		subfilter = getSearchFilter(OBJECTCLASS_USER);
-		if (contacttype)
-			subfilter += getSearchFilter(NONACTIVE_CONTACT);
+		/* No objectclass is given, merge all filters together. */
+		subfilter = "(|";
+		subfilter += getSearchFilter(OBJECTCLASS_USER);
 		subfilter += getSearchFilter(OBJECTCLASS_DISTLIST);
 		subfilter += getSearchFilter(OBJECTCLASS_CONTAINER);
-		subfilter = "(|" + subfilter + ")";
+		subfilter += ")";
 		break;
 	case OBJECTCLASS_USER:
 	case ACTIVE_USER:


### PR DESCRIPTION
Currently, the LDAP plugin of Kopano only implements user/contact differentiation through object classes (ldap_user_type_attribute_value, ldap_contact_type_attribute_value), with both types getting the user filter applied. In the scenario of an Active Directory which contains only user objects (due to service logins associated with those), there needs to be an additional method to discriminate between (mail-)users and (mail-)contacts, irrespective of the object class, which is currently not available. The present workaround, generating a login account object which is excluded by the user filter from Kopano and additionally a contact object for the same user which is included, is error-prone, as now two objects in the directory have to be managed concurrently.

This patch implements an additional attribute check (ldap_user_local_attribute) which tests whether an object which is resolved as a user (by object class) is local (mail served by Kopano, either full user, room, equipment, etc.), or non-local (mail not served by Kopano, a contact). It does this by testing whether the attribute defined by ldap_user_local_attribute has a value set up for the corresponding object which resolved as a user (=local), or doesn't (=non-local).

The latter choice (i.e., not implementing an additional filter, but using attribute presence only) was taken to allow reuse of the kopanoUserServer attribute, which is currently only relevant for multi-server installations, but now can be used in single server installations to implement local/non-local discrimination and is also directly editable through the ADUC-integration of Kopano. For multi-server installations, the same logic (user without a home-server is always a contact) is also applicable.

The updates to the LDAP logic are dependent on ldap_user_local_attribute being set; in case the parameter is not set (empty), the LDAP user plugin works as it does currently, so that the changes are backwards compatible. The default for ldap_user_local_attribute is empty.