### PR TITLE
libtidy-support not compiled for dagent.cpp and imap.cpp

### DIFF
--- a/gateway/IMAP.cpp
+++ b/gateway/IMAP.cpp
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  * Copyright 2005 - 2016 Zarafa and its licensors
  */
+#ifdef HAVE_CONFIG_H
+#	include "config.h"
+#endif
 #include <kopano/platform.h>
 #include <iterator>
 #include <memory>

--- a/spooler/DAgent.cpp
+++ b/spooler/DAgent.cpp
@@ -31,6 +31,9 @@
  * Detail:
  * see rfc.
  */
+#ifdef HAVE_CONFIG_H
+#       include "config.h"
+#endif
 #include <kopano/platform.h>
 #include <atomic>
 #include <memory>


### PR DESCRIPTION
With _tidybuffio.h_ present, libtidy-support is not compiled for _dagent.cpp_ and _imap.cpp:_
In order to consume automake-variables, _config.h_ needs to be pulled in, first. Otherwise HAVE_xxx will be left undefined, which effectively skips _HAVE_TIDYBUFFIO_H_ scopes.

Signed-off-by: Armin Schöffmann <armin.schoeffmann@aegaeon.de>