### PR TITLE
localeutil.cpp: Operate on stack instead of returned pointer in forceUTF8Locale

### DIFF
--- a/common/charset/localeutil.cpp
+++ b/common/charset/localeutil.cpp
@@ -53,12 +53,13 @@ exit:
 bool forceUTF8Locale(bool bOutput, std::string *lpstrLastSetLocale)
 {
 	std::string new_locale;
-	char *old_locale = setlocale(LC_CTYPE, "");
-	if (!old_locale) {
+	char *orig_locale = setlocale(LC_CTYPE, ""), old_locale[512];
+	if (!orig_locale) {
 		if (bOutput)
 			std::cerr << "Unable to initialize locale" << std::endl;
 		return false;
 	}
+	strncpy(old_locale, orig_locale, sizeof(old_locale));
 	char *dot = strchr(old_locale, '.');
 	if (dot) {
 		*dot = '\0';


### PR DESCRIPTION
The pointer returned by setlocale(LC_CTYPE, "") does not necessarily point to a RW mapped memory page. In muslibc, the page is mapped READ only, so writing to it later fails with a segfault.
This patch makes the function operate on the stack instead, so the segfault is avoided without implicit dependency on any particular libc.