### PR TITLE
Update kopano-spamd

### DIFF
--- a/ECtools/spamd/kopano_spamd/__init__.py
+++ b/ECtools/spamd/kopano_spamd/__init__.py
@@ -82,7 +82,7 @@ class Importer:
 
             elif (item.folder == item.store.inbox and \
                   self.learnham and \
-                  self.was_spam(searchkey)):
+                  (self.was_spam(searchkey) or header.upper() == 'YES')):
 
                 fn = os.path.join(self.spamdir, searchkey + '.eml')
                 if os.path.isfile(fn):


### PR DESCRIPTION
Allow ham recognition if mail was automatically moved to junk folder.
Currently it is not possible to trigger ham code path if the mail was moved to junk by some other program like amavis.
So instead of relying on just the database a fallback to the header should be done, to recognize spam flagged by other mechanisms.